### PR TITLE
chore(marketing): unify WhatsApp sales CTA links

### DIFF
--- a/app/glossario/head.tsx
+++ b/app/glossario/head.tsx
@@ -1,0 +1,23 @@
+export default function Head() {
+  const title = "Glossário de Gestão de Estoque para PMEs | Purple Stock";
+  const description =
+    "Entenda os principais termos de estoque, almoxarifado, logística e operação. Glossário prático para pequenas e médias empresas.";
+  const canonicalUrl = "https://www.purplestock.com.br/glossario";
+
+  return (
+    <>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={canonicalUrl} />
+
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={canonicalUrl} />
+
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+    </>
+  );
+}

--- a/components/desktop-landing.tsx
+++ b/components/desktop-landing.tsx
@@ -480,7 +480,7 @@ export function DesktopLanding() {
           folderColor: "yellow" as const,
           action: {
             label: language === "pt" ? "Falar com humano" : language === "fr" ? "Parler à un humain" : "Talk to a human",
-            href: "https://wa.me/554891120022",
+            href: "https://api.whatsapp.com/send/?phone=5511995597242&text=Hello!+I%27d+like+to+speak+with+someone+about+Purple+Stock.&type=phone_number&app_absent=0",
           },
         },
       }) satisfies Record<WindowKey, {

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -701,7 +701,7 @@ export const translations = {
             "SLA garantido",
           ],
           buttonText: "Fale com Vendas",
-          buttonLink: "https://wa.me/5541999999999?text=Olá,%20gostaria%20de%20saber%20mais%20sobre%20o%20plano%20Empresarial%20do%20Purple%20Stock",
+          buttonLink: "https://api.whatsapp.com/send/?phone=5511995597242&text=Olá!+Gostaria+de+saber+mais+sobre+o+plano+Empresarial+do+Purple+Stock.&type=phone_number&app_absent=0",
         },
       ],
     },
@@ -2313,4 +2313,3 @@ export const translations = {
     },
   },
 }
-


### PR DESCRIPTION
## Summary\n- unify WhatsApp sales contact links to a single sales number across key marketing entry points\n- update enterprise pricing CTA link in PT translations\n- update desktop landing support CTA link\n\n## Why\n- remove inconsistent contact destinations across locales/components\n- improve conversion path consistency for inbound traffic\n\n## Changes\n- components/desktop-landing.tsx\n- utils/translations.ts