### PR TITLE
fix(seo): corrigir canonical e completar redirects legados do blog

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const articleUrl = `${baseUrl}/blog/${post.meta.slug}`
 
   return {
-    title: `${post.meta.title} | Purple Stock`,
+    title: post.meta.title,
     description: post.meta.excerpt,
     alternates: {
       canonical: articleUrl,

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -9,8 +9,11 @@ import { Footer } from "@/components/footer"
 const POSTS_PER_PAGE = 10
 
 export const metadata: Metadata = {
-  title: "Blog | Purple Stock",
+  title: "Blog",
   description: "Artigos práticos sobre controle de estoque, rastreabilidade e eficiência operacional.",
+  alternates: {
+    canonical: "/blog",
+  },
 }
 
 function formatDate(date: string) {

--- a/app/blog/tag/[tag]/page.tsx
+++ b/app/blog/tag/[tag]/page.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
 
   return {
-    title: `Blog: ${label} | Purple Stock`,
+    title: `Blog: ${label}`,
     description: `Artigos sobre ${label} no blog da Purple Stock.`,
     alternates: {
       canonical: `${baseUrl}/blog/tag/${tag}`,

--- a/app/industrias/head.tsx
+++ b/app/industrias/head.tsx
@@ -1,0 +1,23 @@
+import { getSiteUrl } from "@/lib/site"
+
+export default function Head() {
+  const canonicalUrl = `${getSiteUrl()}/industrias`
+  const title = "Controle de Estoque por Setor | Purple Stock"
+  const description =
+    "Conheça as soluções da Purple Stock por setor: indústria, varejo, logística e mais, com rastreabilidade e operação em tempo real."
+
+  return (
+    <>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={canonicalUrl} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+    </>
+  )
+}

--- a/app/precos/head.tsx
+++ b/app/precos/head.tsx
@@ -1,0 +1,23 @@
+import { getSiteUrl } from "@/lib/site"
+
+export default function Head() {
+  const canonicalUrl = `${getSiteUrl()}/precos`
+  const title = "Preços Purple Stock: R$ 29,90 por time"
+  const description =
+    "Plano único da Purple Stock: R$ 29,90 por time por mês, com 7 dias grátis, sem fidelidade e operação com QR Code."
+
+  return (
+    <>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={canonicalUrl} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+    </>
+  )
+}

--- a/app/recursos/controle-de-almoxarifado/head.tsx
+++ b/app/recursos/controle-de-almoxarifado/head.tsx
@@ -1,0 +1,23 @@
+import { getSiteUrl } from "@/lib/site"
+
+export default function Head() {
+  const canonicalUrl = `${getSiteUrl()}/recursos/controle-de-almoxarifado`
+  const title = "Controle de Almoxarifado: Guia Prático para PMEs | Purple Stock"
+  const description =
+    "Entenda como estruturar controle de almoxarifado com entrada e saída, inventário cíclico e rastreabilidade para reduzir erros e custos."
+
+  return (
+    <>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={canonicalUrl} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+    </>
+  )
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -41,12 +41,24 @@ const nextConfig = {
         destination: "/blog/open-erp-o-que-e-e-quando-usar",
       },
       {
+        source: "/blog/open-erp-o-que-e-e-como-ele-pode-ajudar-sua-empresa",
+        destination: "/blog/open-erp-o-que-e-e-quando-usar",
+      },
+      {
         source: "/blog/sistema-de-controle-de-almoxarifado",
+        destination: "/recursos/controle-de-almoxarifado",
+      },
+      {
+        source: "/blog/sistema-de-controle-de-almoxarifado-a-solucao-para-a-eficiencia-e-reducao-de-custos-na-gestao-de-estoques",
         destination: "/recursos/controle-de-almoxarifado",
       },
       {
         source: "/blog/como-implementar-um-controle-de-faccao-eficiente-estrategias-para-otimizar-a-producao-na-confeccao",
         destination: "/features/clothing-manufacturing",
+      },
+      {
+        source: "/blog/maximizando-a-eficiencia-do-controle-de-inventario-com-tecnologia-qr-code",
+        destination: "/blog/como-usar-qr-code-controle-estoque",
       },
     ]
 


### PR DESCRIPTION
## Resumo
Este PR corrige bloqueios técnicos de SEO identificados na auditoria da new_lp:

- Corrige canonical e title da listagem de blog
- Remove duplicação de marca no title das páginas de post/tag
- Adiciona metadata dedicada para páginas estratégicas (/precos, /industrias, /recursos/controle-de-almoxarifado)
- Completa mapa de redirects legados do subdomínio blog para evitar 404 em URLs antigas com impressões no GSC

## Arquivos alterados
- app/blog/page.tsx
- app/blog/[slug]/page.tsx
- app/blog/tag/[tag]/page.tsx
- app/precos/head.tsx
- app/industrias/head.tsx
- app/recursos/controle-de-almoxarifado/head.tsx
- next.config.mjs

## Validação
- npm run lint ✅
- npm run build ⚠️ falha por RESEND_API_KEY ausente em rota de email (/api/email/welcome), não relacionado às mudanças de SEO

## Impacto esperado
- Redução de problemas de canonical incorreto
- Recuperação de tráfego legado via redirects corretos
- Melhora de CTR por snippets mais alinhados em URLs de negócio
