### PR TITLE
fix: add outputFileTracingRoot to silence lockfile warning

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,6 +17,7 @@ const nextConfig = {
   images: {
     formats: ["image/avif", "image/webp"],
   },
+  outputFileTracingRoot: new URL(".", import.meta.url).pathname,
   experimental: {
     webpackBuildWorker: true,
     parallelServerBuildTraces: true,


### PR DESCRIPTION
Explicitly sets `outputFileTracingRoot` to the `new_lp` directory so Next.js doesn't warn about detecting multiple lockfiles (`package-lock.json` at repo root + `pnpm-lock.yaml` in `new_lp`).