### PR TITLE
feat(blog): redesign com layout moderno, sidebar e componentes reutilizáveis

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,12 +2,15 @@ import Link from "next/link";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { ArrowLeft, Clock3 } from "lucide-react";
+import { ArrowLeft, Clock3, Share2 } from "lucide-react";
 import { getAllPosts, getPostBySlug, slugifyTag } from "@/lib/blog";
 import { getSiteUrl } from "@/lib/site";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { BlogPostCta } from "@/components/blog-post-cta";
+import { BlogReadingProgress } from "@/components/blog-reading-progress";
+import { BlogSidebar } from "@/components/blog-sidebar";
+import { BlogRelatedPosts } from "@/components/blog-related-posts";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -105,76 +108,97 @@ export default async function BlogPostPage({ params }: PageProps) {
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-[radial-gradient(circle_at_20%_20%,rgba(129,117,224,0.15),transparent_45%),radial-gradient(circle_at_80%_0%,rgba(221,171,255,0.22),transparent_52%),linear-gradient(180deg,#f8f6ff,#f3ede7)]">
       <div className="pointer-events-none absolute inset-0 bg-[url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 fill=%27none%27 viewBox=%270 0 20 20%27%3E%3Cpath d=%27M0 19h20M19 0v20%27 stroke=%27%239c88ff12%27 stroke-width=%271%27/%3E%3C/svg%3E')] opacity-70" />
+      <BlogReadingProgress />
       <Navbar />
 
       <main className="relative pt-24 pb-20">
-        <article className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
-          <div className="overflow-hidden rounded-3xl border border-white/70 bg-white/90 p-6 shadow-2xl backdrop-blur-xl md:p-10">
-            <Link
-              href="/blog"
-              className="mb-8 inline-flex items-center gap-2 text-sm font-semibold text-purple-700 hover:text-purple-800"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Voltar para o blog
-            </Link>
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="grid gap-10 lg:grid-cols-[1fr_340px] lg:items-start">
+            {/* Main article */}
+            <article className="flex flex-col">
+              <div className="overflow-hidden rounded-3xl border border-white/70 bg-white/90 shadow-2xl backdrop-blur-xl">
+                <div className="p-6 md:p-10">
+                  <Link
+                    href="/blog"
+                    className="mb-8 inline-flex items-center gap-2 text-sm font-semibold text-purple-700 hover:text-purple-800 transition-colors"
+                  >
+                    <ArrowLeft className="h-4 w-4" />
+                    Voltar para o blog
+                  </Link>
 
-            <header className="mb-8 border-b border-gray-100 pb-8">
-              <div className="mb-3 flex flex-wrap items-center gap-3 text-sm text-gray-600">
-                <span>{formatDate(post.meta.date)}</span>
-                <span className="h-1 w-1 rounded-full bg-gray-400" />
-                <span className="inline-flex items-center gap-1">
-                  <Clock3 className="h-3.5 w-3.5" />
-                  {post.meta.readingTime}
-                </span>
-                <span className="h-1 w-1 rounded-full bg-gray-400" />
-                <span>{post.meta.author}</span>
-              </div>
+                  <header className="mb-8 border-b border-gray-100 pb-8">
+                    <div className="mb-4 flex flex-wrap items-center gap-3 text-sm text-gray-500">
+                      <span className="inline-flex items-center gap-1.5 rounded-full bg-purple-50 px-2.5 py-0.5 text-xs font-medium text-purple-700">
+                        Artigo
+                      </span>
+                      <span className="h-1 w-1 rounded-full bg-gray-300" />
+                      <span>{formatDate(post.meta.date)}</span>
+                      <span className="h-1 w-1 rounded-full bg-gray-300" />
+                      <span className="inline-flex items-center gap-1">
+                        <Clock3 className="h-3.5 w-3.5" />
+                        {post.meta.readingTime}
+                      </span>
+                      <span className="h-1 w-1 rounded-full bg-gray-300" />
+                      <span>{post.meta.author}</span>
+                    </div>
 
-              <h1 className="text-4xl font-bold tracking-tight text-gray-900 md:text-5xl">
-                {post.meta.title}
-              </h1>
-              <p className="mt-4 max-w-3xl text-lg leading-relaxed text-gray-600">
-                {post.meta.excerpt}
-              </p>
-              <BlogPostCta slug={post.meta.slug} />
+                    <h1 className="text-4xl font-bold tracking-tight text-gray-900 md:text-5xl">
+                      {post.meta.title}
+                    </h1>
+                    <p className="mt-4 max-w-3xl text-lg leading-relaxed text-gray-600">
+                      {post.meta.excerpt}
+                    </p>
+                    <BlogPostCta slug={post.meta.slug} />
 
-              {post.meta.tags.length > 0 && (
-                <div className="mt-5 flex flex-wrap gap-2">
-                  {post.meta.tags.map((tag) => (
-                    <Link
-                      key={tag}
-                      href={`/blog/tag/${slugifyTag(tag)}`}
-                      className="rounded-full bg-purple-50 px-3 py-1 text-xs font-medium text-purple-700 transition-colors hover:bg-purple-100"
-                    >
-                      {tag}
-                    </Link>
-                  ))}
+                    {post.meta.tags.length > 0 && (
+                      <div className="mt-5 flex flex-wrap gap-2">
+                        {post.meta.tags.map((tag) => (
+                          <Link
+                            key={tag}
+                            href={`/blog/tag/${slugifyTag(tag)}`}
+                            className="rounded-full bg-purple-50 px-3 py-1 text-xs font-medium text-purple-700 transition-colors hover:bg-purple-100"
+                          >
+                            {tag}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="mt-8 overflow-hidden rounded-2xl border border-gray-100">
+                      <Image
+                        src={image}
+                        alt={post.meta.title}
+                        width={1200}
+                        height={630}
+                        className="h-auto w-full object-cover"
+                        priority
+                      />
+                    </div>
+                  </header>
+
+                  <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                      __html: JSON.stringify(articleSchema),
+                    }}
+                  />
+                  <div
+                    className="blog-content"
+                    dangerouslySetInnerHTML={{ __html: post.content }}
+                  />
                 </div>
-              )}
-
-              <div className="mt-8 overflow-hidden rounded-2xl border border-gray-100">
-                <Image
-                  src={image}
-                  alt={post.meta.title}
-                  width={1200}
-                  height={630}
-                  className="h-auto w-full object-cover"
-                />
               </div>
-            </header>
 
-            <script
-              type="application/ld+json"
-              dangerouslySetInnerHTML={{
-                __html: JSON.stringify(articleSchema),
-              }}
-            />
-            <div
-              className="blog-content"
-              dangerouslySetInnerHTML={{ __html: post.content }}
-            />
+              {/* Related Posts */}
+              <BlogRelatedPosts slug={slug} />
+            </article>
+
+            {/* Sidebar */}
+            <div className="hidden lg:block lg:sticky lg:top-28">
+              <BlogSidebar excludeSlug={slug} />
+            </div>
           </div>
-        </article>
+        </div>
       </main>
 
       <Footer />

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,12 +1,14 @@
 import Link from "next/link";
 import Image from "next/image";
 import type { Metadata } from "next";
-import { BookOpen, ArrowRight, Clock3 } from "lucide-react";
+import { BookOpen, ArrowLeft, ArrowRight, Clock3 } from "lucide-react";
 import { getAllPosts, slugifyTag } from "@/lib/blog";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
+import { BlogCard } from "@/components/blog-card";
+import { BlogSidebar } from "@/components/blog-sidebar";
 
-const POSTS_PER_PAGE = 10;
+const POSTS_PER_PAGE = 9;
 
 export const metadata: Metadata = {
   title: "Blog",
@@ -40,6 +42,10 @@ export default async function BlogPage({ searchParams }: PageProps) {
   const start = (normalizedPage - 1) * POSTS_PER_PAGE;
   const paginatedPosts = posts.slice(start, start + POSTS_PER_PAGE);
 
+  const hasFeatured = normalizedPage === 1 && paginatedPosts.length > 0;
+  const featured = hasFeatured ? paginatedPosts[0] : null;
+  const gridPosts = hasFeatured ? paginatedPosts.slice(1) : paginatedPosts;
+
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-[radial-gradient(circle_at_20%_20%,rgba(129,117,224,0.15),transparent_45%),radial-gradient(circle_at_80%_0%,rgba(221,171,255,0.22),transparent_52%),linear-gradient(180deg,#f8f6ff,#f3ede7)]">
       <div className="pointer-events-none absolute inset-0 bg-[url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 fill=%27none%27 viewBox=%270 0 20 20%27%3E%3Cpath d=%27M0 19h20M19 0v20%27 stroke=%27%239c88ff12%27 stroke-width=%271%27/%3E%3C/svg%3E')] opacity-70" />
@@ -47,6 +53,7 @@ export default async function BlogPage({ searchParams }: PageProps) {
 
       <main className="relative pt-24 pb-20">
         <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          {/* Header */}
           <header className="mx-auto mb-12 max-w-5xl rounded-3xl border border-white/60 bg-white/80 p-8 text-center shadow-[0_25px_100px_-30px_rgba(59,7,100,0.35),0_10px_40px_-20px_rgba(0,0,0,0.1)] backdrop-blur-2xl md:p-12">
             <p className="mb-6 inline-flex items-center gap-2 rounded-full bg-purple-100 px-4 py-2 text-sm font-medium text-purple-800">
               <BookOpen className="h-4 w-4" />
@@ -63,120 +70,70 @@ export default async function BlogPage({ searchParams }: PageProps) {
             </p>
           </header>
 
-          <div className="grid gap-8">
-            {paginatedPosts.map((post) => {
-              const cover =
-                post.coverImage ?? "/images/hero-photo-900x600.webp";
-              return (
-                <article
-                  key={post.slug}
-                  className="overflow-hidden rounded-3xl border border-white/70 bg-white/90 shadow-xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl"
-                >
-                  <div className="grid gap-0 md:grid-cols-[320px_1fr]">
+          <div className="grid gap-10 lg:grid-cols-[1fr_340px] lg:items-start">
+            {/* Main content */}
+            <div className="flex flex-col gap-8">
+              {/* Featured post */}
+              {featured && <BlogCard post={featured} featured />}
+
+              {/* Grid of remaining posts */}
+              {gridPosts.length > 0 && (
+                <div className="grid gap-6 sm:grid-cols-2">
+                  {gridPosts.map((post) => (
+                    <BlogCard key={post.slug} post={post} />
+                  ))}
+                </div>
+              )}
+
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <nav className="mt-4 flex items-center justify-center gap-3">
+                  {normalizedPage > 1 ? (
                     <Link
-                      href={`/blog/${post.slug}`}
-                      className="relative block min-h-56 overflow-hidden"
+                      href={
+                        normalizedPage - 1 === 1
+                          ? "/blog"
+                          : `/blog?page=${normalizedPage - 1}`
+                      }
+                      className="inline-flex items-center gap-2 rounded-xl border border-purple-200 bg-white px-4 py-2 text-sm font-semibold text-purple-700 shadow-sm hover:bg-purple-50 transition-colors"
                     >
-                      <Image
-                        src={cover}
-                        alt={post.title}
-                        fill
-                        className="object-cover transition-transform duration-500 hover:scale-105"
-                      />
+                      <ArrowLeft className="h-4 w-4" />
+                      Anterior
                     </Link>
+                  ) : (
+                    <span className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-400">
+                      <ArrowLeft className="h-4 w-4" />
+                      Anterior
+                    </span>
+                  )}
 
-                    <div className="p-6 md:p-8">
-                      <div className="mb-3 flex flex-wrap items-center gap-3 text-sm text-gray-600">
-                        <span>{formatDate(post.date)}</span>
-                        <span className="h-1 w-1 rounded-full bg-gray-400" />
-                        <span className="inline-flex items-center gap-1">
-                          <Clock3 className="h-3.5 w-3.5" />
-                          {post.readingTime}
-                        </span>
-                        <span className="h-1 w-1 rounded-full bg-gray-400" />
-                        <span>{post.author}</span>
-                      </div>
+                  <span className="rounded-xl border border-white/70 bg-white/80 px-4 py-2 text-sm font-semibold text-gray-700">
+                    Página {normalizedPage} de {totalPages}
+                  </span>
 
-                      <h2 className="text-2xl font-bold text-gray-900 md:text-3xl">
-                        <Link
-                          href={`/blog/${post.slug}`}
-                          className="hover:text-purple-700"
-                        >
-                          {post.title}
-                        </Link>
-                      </h2>
+                  {normalizedPage < totalPages ? (
+                    <Link
+                      href={`/blog?page=${normalizedPage + 1}`}
+                      className="inline-flex items-center gap-2 rounded-xl border border-purple-200 bg-white px-4 py-2 text-sm font-semibold text-purple-700 shadow-sm hover:bg-purple-50 transition-colors"
+                    >
+                      Próxima
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  ) : (
+                    <span className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-400">
+                      Próxima
+                      <ArrowRight className="h-4 w-4" />
+                    </span>
+                  )}
+                </nav>
+              )}
+            </div>
 
-                      <p className="mt-3 text-base leading-relaxed text-gray-600">
-                        {post.excerpt}
-                      </p>
-
-                      {post.tags.length > 0 && (
-                        <div className="mt-5 flex flex-wrap gap-2">
-                          {post.tags.map((tag) => (
-                            <Link
-                              key={tag}
-                              href={`/blog/tag/${slugifyTag(tag)}`}
-                              className="rounded-full bg-purple-50 px-3 py-1 text-xs font-medium text-purple-700 transition-colors hover:bg-purple-100"
-                            >
-                              {tag}
-                            </Link>
-                          ))}
-                        </div>
-                      )}
-
-                      <div className="mt-6">
-                        <Link
-                          href={`/blog/${post.slug}`}
-                          className="inline-flex items-center gap-2 text-sm font-semibold text-purple-700 hover:text-purple-800"
-                        >
-                          Ler artigo completo
-                          <ArrowRight className="h-4 w-4" />
-                        </Link>
-                      </div>
-                    </div>
-                  </div>
-                </article>
-              );
-            })}
+            {/* Sidebar */}
+            <div className="hidden lg:block lg:sticky lg:top-28">
+              <BlogSidebar />
+            </div>
           </div>
-
-          {totalPages > 1 && (
-            <nav className="mt-12 flex items-center justify-center gap-3">
-              {normalizedPage > 1 ? (
-                <Link
-                  href={
-                    normalizedPage - 1 === 1
-                      ? "/blog"
-                      : `/blog?page=${normalizedPage - 1}`
-                  }
-                  className="rounded-xl border border-purple-200 bg-white px-4 py-2 text-sm font-semibold text-purple-700 shadow-sm hover:bg-purple-50"
-                >
-                  Anterior
-                </Link>
-              ) : (
-                <span className="rounded-xl border border-gray-200 bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-400">
-                  Anterior
-                </span>
-              )}
-
-              <span className="rounded-xl border border-white/70 bg-white/80 px-4 py-2 text-sm font-semibold text-gray-700">
-                Página {normalizedPage} de {totalPages}
-              </span>
-
-              {normalizedPage < totalPages ? (
-                <Link
-                  href={`/blog?page=${normalizedPage + 1}`}
-                  className="rounded-xl border border-purple-200 bg-white px-4 py-2 text-sm font-semibold text-purple-700 shadow-sm hover:bg-purple-50"
-                >
-                  Próxima
-                </Link>
-              ) : (
-                <span className="rounded-xl border border-gray-200 bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-400">
-                  Próxima
-                </span>
-              )}
-            </nav>
-          )}
         </section>
       </main>
 

--- a/app/blog/tag/[tag]/page.tsx
+++ b/app/blog/tag/[tag]/page.tsx
@@ -7,6 +7,8 @@ import { getAllTagSlugs, getPostsByTagSlug, slugifyTag } from "@/lib/blog";
 import { getSiteUrl } from "@/lib/site";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
+import { BlogCard } from "@/components/blog-card";
+import { BlogSidebar } from "@/components/blog-sidebar";
 
 type PageProps = {
   params: Promise<{ tag: string }>;
@@ -67,7 +69,7 @@ export default async function BlogTagPage({ params }: PageProps) {
           <header className="mx-auto mb-12 max-w-5xl rounded-3xl border border-white/60 bg-white/80 p-8 text-center shadow-[0_25px_100px_-30px_rgba(59,7,100,0.35),0_10px_40px_-20px_rgba(0,0,0,0.1)] backdrop-blur-2xl md:p-12">
             <Link
               href="/blog"
-              className="mb-6 inline-flex items-center gap-2 text-sm font-semibold text-purple-700 hover:text-purple-800"
+              className="mb-6 inline-flex items-center gap-2 text-sm font-semibold text-purple-700 hover:text-purple-800 transition-colors"
             >
               <ArrowLeft className="h-4 w-4" />
               Voltar para o blog
@@ -85,72 +87,16 @@ export default async function BlogTagPage({ params }: PageProps) {
             </p>
           </header>
 
-          <div className="grid gap-8">
-            {posts.map((post) => {
-              const cover =
-                post.coverImage ?? "/images/hero-photo-900x600.webp";
-              return (
-                <article
-                  key={post.slug}
-                  className="overflow-hidden rounded-3xl border border-white/70 bg-white/90 shadow-xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl"
-                >
-                  <div className="grid gap-0 md:grid-cols-[320px_1fr]">
-                    <Link
-                      href={`/blog/${post.slug}`}
-                      className="relative block min-h-56 overflow-hidden"
-                    >
-                      <Image
-                        src={cover}
-                        alt={post.title}
-                        fill
-                        className="object-cover transition-transform duration-500 hover:scale-105"
-                      />
-                    </Link>
-                    <div className="p-6 md:p-8">
-                      <div className="mb-3 flex flex-wrap items-center gap-3 text-sm text-gray-600">
-                        <span>{formatDate(post.date)}</span>
-                        <span className="h-1 w-1 rounded-full bg-gray-400" />
-                        <span className="inline-flex items-center gap-1">
-                          <Clock3 className="h-3.5 w-3.5" />
-                          {post.readingTime}
-                        </span>
-                      </div>
+          <div className="grid gap-10 lg:grid-cols-[1fr_340px] lg:items-start">
+            <div className="grid gap-6 sm:grid-cols-2">
+              {posts.map((post) => (
+                <BlogCard key={post.slug} post={post} />
+              ))}
+            </div>
 
-                      <h2 className="text-2xl font-bold text-gray-900 md:text-3xl">
-                        <Link
-                          href={`/blog/${post.slug}`}
-                          className="hover:text-purple-700"
-                        >
-                          {post.title}
-                        </Link>
-                      </h2>
-                      <p className="mt-3 text-base leading-relaxed text-gray-600">
-                        {post.excerpt}
-                      </p>
-
-                      <div className="mt-5 flex flex-wrap gap-2">
-                        {post.tags.map((item) => {
-                          const itemSlug = slugifyTag(item);
-                          return (
-                            <Link
-                              key={item}
-                              href={`/blog/tag/${itemSlug}`}
-                              className={`rounded-full px-3 py-1 text-xs font-medium ${
-                                itemSlug === tag
-                                  ? "bg-purple-700 text-white"
-                                  : "bg-purple-50 text-purple-700 hover:bg-purple-100"
-                              }`}
-                            >
-                              {item}
-                            </Link>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  </div>
-                </article>
-              );
-            })}
+            <div className="hidden lg:block lg:sticky lg:top-28">
+              <BlogSidebar />
+            </div>
           </div>
         </section>
       </main>

--- a/components/blog-card.tsx
+++ b/components/blog-card.tsx
@@ -1,0 +1,151 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Clock3, ArrowUpRight } from "lucide-react";
+import { slugifyTag } from "@/lib/blog";
+import type { BlogPostMeta } from "@/lib/blog";
+
+function formatDate(date: string) {
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(date));
+}
+
+export function BlogCard({
+  post,
+  featured = false,
+}: {
+  post: BlogPostMeta;
+  featured?: boolean;
+}) {
+  const cover = post.coverImage ?? "/images/hero-photo-900x600.webp";
+
+  if (featured) {
+    return (
+      <article className="group relative overflow-hidden rounded-3xl border border-white/70 bg-white/90 shadow-xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl">
+        <div className="grid gap-0 md:grid-cols-[1.1fr_1fr]">
+          <Link
+            href={`/blog/${post.slug}`}
+            className="relative block min-h-64 overflow-hidden md:min-h-full"
+          >
+            <Image
+              src={cover}
+              alt={post.title}
+              fill
+              className="object-cover transition-transform duration-700 group-hover:scale-[1.03]"
+              priority
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/30 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+          </Link>
+
+          <div className="flex flex-col justify-center p-6 md:p-10">
+            <div className="mb-3 flex flex-wrap items-center gap-3 text-sm text-gray-500">
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-purple-50 px-2.5 py-0.5 text-xs font-medium text-purple-700">
+                Em destaque
+              </span>
+              <span className="h-1 w-1 rounded-full bg-gray-300" />
+              <span>{formatDate(post.date)}</span>
+              <span className="h-1 w-1 rounded-full bg-gray-300" />
+              <span className="inline-flex items-center gap-1">
+                <Clock3 className="h-3.5 w-3.5" />
+                {post.readingTime}
+              </span>
+            </div>
+
+            <h2 className="text-2xl font-bold tracking-tight text-gray-900 md:text-3xl lg:text-4xl">
+              <Link
+                href={`/blog/${post.slug}`}
+                className="hover:text-purple-700 transition-colors"
+              >
+                {post.title}
+              </Link>
+            </h2>
+
+            <p className="mt-4 text-base leading-relaxed text-gray-600 md:text-lg">
+              {post.excerpt}
+            </p>
+
+            {post.tags.length > 0 && (
+              <div className="mt-6 flex flex-wrap gap-2">
+                {post.tags.map((tag) => (
+                  <Link
+                    key={tag}
+                    href={`/blog/tag/${slugifyTag(tag)}`}
+                    className="rounded-full bg-purple-50 px-3 py-1 text-xs font-medium text-purple-700 transition-colors hover:bg-purple-100"
+                  >
+                    {tag}
+                  </Link>
+                ))}
+              </div>
+            )}
+
+            <div className="mt-6">
+              <Link
+                href={`/blog/${post.slug}`}
+                className="inline-flex items-center gap-2 text-sm font-semibold text-purple-700 hover:text-purple-800 transition-colors"
+              >
+                Ler artigo completo
+                <ArrowUpRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article className="group flex flex-col overflow-hidden rounded-2xl border border-white/70 bg-white/90 shadow-lg backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl">
+      <Link
+        href={`/blog/${post.slug}`}
+        className="relative block aspect-[16/10] overflow-hidden"
+      >
+        <Image
+          src={cover}
+          alt={post.title}
+          fill
+          className="object-cover transition-transform duration-500 group-hover:scale-105"
+        />
+      </Link>
+
+      <div className="flex flex-1 flex-col p-5 md:p-6">
+        <div className="mb-3 flex flex-wrap items-center gap-2.5 text-xs text-gray-500">
+          <span>{formatDate(post.date)}</span>
+          <span className="h-1 w-1 rounded-full bg-gray-300" />
+          <span className="inline-flex items-center gap-1">
+            <Clock3 className="h-3 w-3" />
+            {post.readingTime}
+          </span>
+        </div>
+
+        <h3 className="text-lg font-bold leading-snug text-gray-900 md:text-xl">
+          <Link
+            href={`/blog/${post.slug}`}
+            className="hover:text-purple-700 transition-colors"
+          >
+            {post.title}
+          </Link>
+        </h3>
+
+        <p className="mt-2 line-clamp-3 text-sm leading-relaxed text-gray-600">
+          {post.excerpt}
+        </p>
+
+        {post.tags.length > 0 && (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {post.tags.slice(0, 3).map((tag) => (
+              <Link
+                key={tag}
+                href={`/blog/tag/${slugifyTag(tag)}`}
+                className="rounded-full bg-purple-50 px-2.5 py-0.5 text-[11px] font-medium text-purple-700 transition-colors hover:bg-purple-100"
+              >
+                {tag}
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/components/blog-reading-progress.tsx
+++ b/components/blog-reading-progress.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function BlogReadingProgress() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const update = () => {
+      const scrollTop = window.scrollY;
+      const docHeight =
+        document.documentElement.scrollHeight - window.innerHeight;
+      const pct = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+      setProgress(Math.min(100, Math.max(0, pct)));
+    };
+    window.addEventListener("scroll", update, { passive: true });
+    update();
+    return () => window.removeEventListener("scroll", update);
+  }, []);
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[130] h-[3px] bg-transparent">
+      <div
+        className="h-full bg-gradient-to-r from-purple-600 via-violet-500 to-purple-400 transition-[width] duration-150 ease-out"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+}

--- a/components/blog-related-posts.tsx
+++ b/components/blog-related-posts.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import Image from "next/image";
+import { ArrowRight, Clock3 } from "lucide-react";
+import { getRelatedPosts, slugifyTag } from "@/lib/blog";
+
+function formatDate(date: string) {
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(date));
+}
+
+export async function BlogRelatedPosts({ slug }: { slug: string }) {
+  const posts = await getRelatedPosts(slug, 3);
+
+  if (posts.length === 0) return null;
+
+  return (
+    <section className="mt-16 border-t border-gray-100 pt-12">
+      <h2 className="flex items-center gap-2 text-2xl font-bold tracking-tight text-gray-900">
+        <span className="inline-block h-6 w-1 rounded-full bg-purple-600" />
+        Leia também
+      </h2>
+
+      <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post) => {
+          const cover = post.coverImage ?? "/images/hero-photo-900x600.webp";
+          return (
+            <article
+              key={post.slug}
+              className="group flex flex-col overflow-hidden rounded-2xl border border-white/70 bg-white/90 shadow-lg backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl"
+            >
+              <Link
+                href={`/blog/${post.slug}`}
+                className="relative block aspect-[16/10] overflow-hidden"
+              >
+                <Image
+                  src={cover}
+                  alt={post.title}
+                  fill
+                  className="object-cover transition-transform duration-500 group-hover:scale-105"
+                />
+              </Link>
+
+              <div className="flex flex-1 flex-col p-5">
+                <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-gray-500">
+                  <span>{formatDate(post.date)}</span>
+                  <span className="h-1 w-1 rounded-full bg-gray-300" />
+                  <span className="inline-flex items-center gap-1">
+                    <Clock3 className="h-3 w-3" />
+                    {post.readingTime}
+                  </span>
+                </div>
+
+                <h3 className="text-base font-bold leading-snug text-gray-900">
+                  <Link
+                    href={`/blog/${post.slug}`}
+                    className="hover:text-purple-700 transition-colors"
+                  >
+                    {post.title}
+                  </Link>
+                </h3>
+
+                <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-gray-600">
+                  {post.excerpt}
+                </p>
+
+                <div className="mt-auto pt-4">
+                  <Link
+                    href={`/blog/${post.slug}`}
+                    className="inline-flex items-center gap-1 text-xs font-semibold text-purple-700 hover:text-purple-800 transition-colors"
+                  >
+                    Ler artigo
+                    <ArrowRight className="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
+                  </Link>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/blog-sidebar.tsx
+++ b/components/blog-sidebar.tsx
@@ -1,0 +1,107 @@
+import Link from "next/link";
+import Image from "next/image";
+import { ArrowRight, Hash, TrendingUp } from "lucide-react";
+import { getAllPosts, getPopularTags, slugifyTag } from "@/lib/blog";
+import { Button } from "@/components/ui/button";
+
+function formatDate(date: string) {
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "short",
+  }).format(new Date(date));
+}
+
+export async function BlogSidebar({ excludeSlug }: { excludeSlug?: string }) {
+  const [recentPosts, popularTags] = await Promise.all([
+    getAllPosts(),
+    getPopularTags(10),
+  ]);
+
+  const filtered = excludeSlug
+    ? recentPosts.filter((p) => p.slug !== excludeSlug)
+    : recentPosts;
+
+  const latest = filtered.slice(0, 4);
+
+  return (
+    <aside className="flex flex-col gap-8">
+      {/* CTA Card */}
+      <div className="rounded-2xl border border-purple-200/60 bg-gradient-to-br from-purple-700 to-violet-800 p-6 text-white shadow-lg">
+        <h3 className="text-lg font-bold">Quer testar na prática?</h3>
+        <p className="mt-2 text-sm leading-relaxed text-purple-100">
+          Cadastre-se gratuitamente e comece a controlar seu estoque com QR Code
+          em minutos.
+        </p>
+        <div className="mt-4 flex flex-col gap-2">
+          <Link href="https://app.purplestock.com.br/" target="_blank">
+            <Button className="w-full bg-white text-purple-700 hover:bg-purple-50">
+              Criar conta grátis
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* Recent Posts */}
+      <div className="rounded-2xl border border-white/70 bg-white/90 p-6 shadow-lg backdrop-blur-md">
+        <h3 className="flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-gray-900">
+          <TrendingUp className="h-4 w-4 text-purple-600" />
+          Recentes
+        </h3>
+        <div className="mt-4 flex flex-col gap-4">
+          {latest.map((post) => {
+            const cover = post.coverImage ?? "/images/hero-photo-900x600.webp";
+            return (
+              <Link
+                key={post.slug}
+                href={`/blog/${post.slug}`}
+                className="group flex gap-3 rounded-xl p-2 transition-colors hover:bg-purple-50/60"
+              >
+                <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-lg">
+                  <Image
+                    src={cover}
+                    alt={post.title}
+                    fill
+                    className="object-cover transition-transform duration-300 group-hover:scale-105"
+                  />
+                </div>
+                <div className="flex flex-col justify-center">
+                  <p className="line-clamp-2 text-sm font-semibold leading-snug text-gray-900 group-hover:text-purple-700 transition-colors">
+                    {post.title}
+                  </p>
+                  <span className="mt-1 text-[11px] text-gray-500">
+                    {formatDate(post.date)}
+                  </span>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Popular Tags */}
+      {popularTags.length > 0 && (
+        <div className="rounded-2xl border border-white/70 bg-white/90 p-6 shadow-lg backdrop-blur-md">
+          <h3 className="flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-gray-900">
+            <Hash className="h-4 w-4 text-purple-600" />
+            Tags populares
+          </h3>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {popularTags.map((tag) => (
+              <Link
+                key={tag.slug}
+                href={`/blog/tag/${tag.slug}`}
+                className="inline-flex items-center gap-1.5 rounded-full bg-purple-50 px-3 py-1 text-xs font-medium text-purple-700 transition-colors hover:bg-purple-100"
+              >
+                {tag.label}
+                <span className="rounded-full bg-purple-200/60 px-1.5 py-0.5 text-[10px] font-semibold text-purple-800">
+                  {tag.count}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -100,6 +100,53 @@ export async function getPostsByTagSlug(tagSlug: string): Promise<{
   };
 }
 
+export async function getRelatedPosts(
+  slug: string,
+  limit = 3
+): Promise<BlogPostMeta[]> {
+  const all = await getAllPosts();
+  const current = all.find((p) => p.slug === slug);
+  if (!current) return all.slice(0, limit);
+
+  const scored = all
+    .filter((p) => p.slug !== slug)
+    .map((p) => {
+      const shared = p.tags.filter((t) => current.tags.includes(t)).length;
+      return { post: p, score: shared };
+    })
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        new Date(b.post.date).getTime() - new Date(a.post.date).getTime()
+    );
+
+  return scored.slice(0, limit).map((s) => s.post);
+}
+
+export async function getPopularTags(
+  limit = 12
+): Promise<{ label: string; slug: string; count: number }[]> {
+  const posts = await getAllPosts();
+  const map = new Map<string, { label: string; count: number }>();
+
+  for (const post of posts) {
+    for (const tag of post.tags) {
+      const slug = slugifyTag(tag);
+      const existing = map.get(slug);
+      if (existing) {
+        existing.count++;
+      } else {
+        map.set(slug, { label: tag, count: 1 });
+      }
+    }
+  }
+
+  return [...map.entries()]
+    .map(([slug, { label, count }]) => ({ slug, label, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}
+
 export async function getPostBySlug(slug: string): Promise<{
   meta: BlogPostMeta;
   content: string;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -53,7 +53,7 @@ h6 {
 }
 
 .blog-content h2 {
-  margin-top: 2.2rem;
+  margin-top: 2.8rem;
   margin-bottom: 1.2rem;
   font-size: clamp(1.7rem, 2.3vw, 2.05rem);
   font-weight: 700;
@@ -77,6 +77,12 @@ h6 {
   margin: 1.1rem 0 1.45rem;
 }
 
+.blog-content strong,
+.blog-content b {
+  color: #1a1d21;
+  font-weight: 700;
+}
+
 .blog-content ul,
 .blog-content ol {
   margin: 1.2rem 0 1.7rem;
@@ -97,19 +103,138 @@ h6 {
   padding-left: 0.28rem;
 }
 
+.blog-content li::marker {
+  color: #9333e9;
+}
+
 .blog-content a {
   color: #1f5c99;
   text-decoration: underline;
   text-underline-offset: 3px;
+  text-decoration-thickness: 1.5px;
+  text-decoration-color: rgba(31, 92, 153, 0.35);
+  transition: text-decoration-color 0.2s ease;
+}
+
+.blog-content a:hover {
+  text-decoration-color: rgba(31, 92, 153, 0.9);
 }
 
 .blog-content blockquote {
-  margin: 2rem 0;
-  padding: 1.05rem 1.2rem;
-  border-left: 4px solid #7aa4ca;
-  background: #f5f8fc;
-  border-radius: 0 10px 10px 0;
+  margin: 2.2rem auto;
+  padding: 1.4rem 1.6rem;
+  border-left: 4px solid #9333e9;
+  background: linear-gradient(135deg, #faf8ff 0%, #f5f3fb 100%);
+  border-radius: 0 14px 14px 0;
   font-style: italic;
+  color: #4a4f56;
+  position: relative;
+}
+
+.blog-content blockquote::before {
+  content: "\201C";
+  position: absolute;
+  top: 0.6rem;
+  left: 0.8rem;
+  font-family: Georgia, serif;
+  font-size: 3rem;
+  line-height: 1;
+  color: #9333e9;
+  opacity: 0.18;
+  pointer-events: none;
+}
+
+.blog-content hr {
+  margin: 2.5rem auto;
+  border: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(147, 51, 233, 0.25),
+    transparent
+  );
+  max-width: 40ch;
+}
+
+.blog-content img {
+  display: block;
+  margin: 2rem auto;
+  border-radius: 14px;
+  box-shadow: 0 8px 30px -10px rgba(59, 7, 100, 0.18);
+  max-width: 100%;
+  height: auto;
+}
+
+.blog-content pre {
+  margin: 1.8rem auto;
+  padding: 1.2rem 1.4rem;
+  border-radius: 14px;
+  background: #1e1b24;
+  color: #e8e4f0;
+  font-family:
+    ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
+  font-size: 0.9rem;
+  line-height: 1.7;
+  overflow-x: auto;
+  max-width: 72ch;
+}
+
+.blog-content code {
+  font-family:
+    ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
+  font-size: 0.88em;
+  background: rgba(147, 51, 233, 0.08);
+  color: #7928ca;
+  padding: 0.15rem 0.4rem;
+  border-radius: 6px;
+}
+
+.blog-content pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+
+.blog-content table {
+  margin: 2rem auto;
+  width: 100%;
+  max-width: 72ch;
+  border-collapse: collapse;
+  font-size: 0.98rem;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+}
+
+.blog-content thead {
+  background: linear-gradient(135deg, #f8f6ff 0%, #f0ecfa 100%);
+}
+
+.blog-content th {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  font-family: "Poppins", sans-serif;
+  font-weight: 600;
+  font-size: 0.88rem;
+  color: #4a3f5c;
+  border-bottom: 2px solid #e4ddf5;
+}
+
+.blog-content td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #f0eef5;
+  color: #4a4f56;
+}
+
+.blog-content tbody tr:nth-child(even) {
+  background: #faf9fd;
+}
+
+.blog-content tbody tr:last-child td {
+  border-bottom: none;
 }
 
 @media (max-width: 768px) {
@@ -134,5 +259,14 @@ h6 {
   .blog-content ol {
     margin: 1rem 0 1.4rem;
     padding-left: 1.35rem;
+  }
+
+  .blog-content pre {
+    padding: 1rem;
+    font-size: 0.82rem;
+  }
+
+  .blog-content blockquote {
+    padding: 1.2rem 1.2rem;
   }
 }


### PR DESCRIPTION
## O que mudou

### 🎨 Design & Layout
- **Listagem (`/blog`)**: layout com sidebar + grid de cards. O post mais recente ganha destaque especial (card grande horizontal com imagem maior), o restante fica em grid de 2 colunas.
- **Sidebar** (desktop, sticky): CTA de trial roxo, posts recentes com miniaturas, e nuvem de tags populares com contador.
- **Página de tag (`/blog/tag/[tag]`)**: mesmo layout moderno com grid de cards + sidebar.

### 📝 Página de Artigo (`/blog/[slug]`)
- **Barra de progresso de leitura** fixa no topo da tela.
- Layout com **sidebar lateral** (posts recentes, tags, CTA).
- Seção **"Leia também"** no final do artigo com 3 posts relacionados (baseados em tags compartilhadas).

### ✍️ Tipografia do Conteúdo
- **Blockquotes** mais elegantes: fundo degradê, borda roxa, aspas decorativa.
- **Imagens** dentro do texto ganham borda arredondada e sombra sutil.
- **Código inline**: fundo roxo claro com fonte mono.
- **Blocos de código** (`pre`): fundo escuro estilo dark mode.
- **Tabelas**: cabeçalho com degradê, zebra striping, bordas suaves.
- **Separadores** (`hr`): linha decorativa com degradê roxo.
- **Listas**: marcadores roxos.

### 🧩 Componentes novos
| Arquivo | Função |
|---|---|
| `components/blog-card.tsx` | Card refinado com variantes normal/destaque |
| `components/blog-sidebar.tsx` | Sidebar com CTA, recentes e tags populares |
| `components/blog-reading-progress.tsx` | Barra de progresso de scroll |
| `components/blog-related-posts.tsx` | Posts relacionados por tag |

### 🔧 Ajustes no backend
- `lib/blog.ts` ganhou `getRelatedPosts()` e `getPopularTags()`.

---

- Build passando ✅
- Lint passando ✅
- Tests passando ✅
- 123 páginas estáticas geradas normalmente