### PR TITLE
feat(codigo-de-barras-gratis): desktop vibe, TDD e melhorias do gerador

### DIFF
--- a/app/codigo-de-barras-gratis/page.tsx
+++ b/app/codigo-de-barras-gratis/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  Box,
   Download,
   Copy,
   BarChart3,
@@ -34,6 +35,20 @@ import JsBarcode from "jsbarcode";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import type { QRCodeErrorCorrectionLevel } from "qrcode";
+import {
+  BARCODE_SIZE_OPTIONS,
+  buildDownloadFilename,
+  buildQrPayload,
+  computeEan13CheckDigit,
+  getBarcodeCanvasDimensions,
+  getQrCanvasDimensions,
+  resolveBarcodeValue,
+  sanitizeBarcodeInput,
+  validateBarcodeData,
+  type BarcodeFormat,
+  type QrPreset,
+  type QrPresetInput,
+} from "@/lib/barcode-generator";
 
 const BARCODE_TYPES = [
   {
@@ -54,11 +69,13 @@ const BARCODE_TYPES = [
   { value: "ITF", label: "ITF", description: "Interleaved 2 of 5" },
 ];
 
-const SIZE_OPTIONS = [
-  { value: "small", label: "Pequeno", dimensions: "200x100" },
-  { value: "medium", label: "Médio", dimensions: "300x150" },
-  { value: "large", label: "Grande", dimensions: "400x200" },
-  { value: "xlarge", label: "Extra Grande", dimensions: "500x250" },
+const QR_PRESETS: { value: QrPreset; label: string }[] = [
+  { value: "url", label: "URL / Link" },
+  { value: "text", label: "Texto" },
+  { value: "email", label: "Email" },
+  { value: "phone", label: "Telefone" },
+  { value: "sms", label: "SMS" },
+  { value: "wifi", label: "WiFi" },
 ];
 
 const QR_ERROR_CORRECTION_LEVELS = [
@@ -99,8 +116,10 @@ export default function CodigoDeBarrasGratis() {
   const [height, setHeight] = useState(100);
   const [fontSize, setFontSize] = useState(20);
 
-  // QR Code specific options
-  const [qrData, setQrData] = useState("https://www.purplestock.com.br");
+  const [qrPreset, setQrPreset] = useState<QrPreset>("url");
+  const [qrFields, setQrFields] = useState<QrPresetInput>({
+    url: "https://www.purplestock.com.br",
+  });
   const [qrSize, setQrSize] = useState(256);
   const [qrErrorCorrection, setQrErrorCorrection] =
     useState<QRCodeErrorCorrectionLevel>("M");
@@ -110,27 +129,98 @@ export default function CodigoDeBarrasGratis() {
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [generationError, setGenerationError] = useState<string | null>(null);
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
 
-  const generateBarcode = useCallback(() => {
-    if (!canvasRef.current || !barcodeData) return;
+  const barcodeValidation = useMemo(
+    () => validateBarcodeData(barcodeType as BarcodeFormat, barcodeData),
+    [barcodeData, barcodeType]
+  );
 
-    setIsGenerating(true);
+  const resolvedBarcodeValue = useMemo(
+    () => resolveBarcodeValue(barcodeType as BarcodeFormat, barcodeData),
+    [barcodeData, barcodeType]
+  );
+
+  const effectiveQrPayload = useMemo(
+    () => buildQrPayload(qrPreset, qrFields),
+    [qrFields, qrPreset]
+  );
+
+  const ean13Suggestion = useMemo(() => {
+    if (barcodeType !== "EAN13") {
+      return null;
+    }
+
+    const digits = sanitizeBarcodeInput("EAN13", barcodeData);
+    if (digits.length !== 12) {
+      return null;
+    }
+
+    return computeEan13CheckDigit(digits);
+  }, [barcodeData, barcodeType]);
+
+  const updateQrField = useCallback(
+    <K extends keyof QrPresetInput>(field: K, value: QrPresetInput[K]) => {
+      setQrFields((current) => ({ ...current, [field]: value }));
+    },
+    []
+  );
+
+  const handleQrPresetChange = useCallback((preset: QrPreset) => {
+    setQrPreset(preset);
+    setGenerationError(null);
+
+    if (preset === "url") {
+      setQrFields({ url: "https://www.purplestock.com.br" });
+      return;
+    }
+
+    if (preset === "text") {
+      setQrFields({ text: "" });
+      return;
+    }
+
+    if (preset === "email") {
+      setQrFields({ email: "", subject: "", body: "" });
+      return;
+    }
+
+    if (preset === "phone") {
+      setQrFields({ phone: "" });
+      return;
+    }
+
+    if (preset === "sms") {
+      setQrFields({ phone: "", message: "" });
+      return;
+    }
+
+    setQrFields({ ssid: "", password: "", security: "WPA" });
+  }, []);
+
+  const renderBarcodePreview = useCallback((): string | null => {
+    if (!canvasRef.current || !resolvedBarcodeValue) {
+      return null;
+    }
+
+    if (!barcodeValidation.valid) {
+      return barcodeValidation.error;
+    }
 
     try {
       const canvas = canvasRef.current;
       const ctx = canvas.getContext("2d");
 
-      if (!ctx) return;
+      if (!ctx) {
+        return null;
+      }
 
-      // Clear canvas
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-      // Set background
       ctx.fillStyle = backgroundColor;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-      // Generate barcode
-      JsBarcode(canvas, barcodeData, {
+      JsBarcode(canvas, resolvedBarcodeValue, {
         format: barcodeType,
         width: lineWidth,
         height: height,
@@ -143,45 +233,44 @@ export default function CodigoDeBarrasGratis() {
         textPosition: "bottom",
         textMargin: 5,
       });
+
+      return null;
     } catch (error) {
-      console.error("Erro ao gerar código de barras:", error);
-    } finally {
-      setIsGenerating(false);
+      return error instanceof Error
+        ? error.message
+        : "Não foi possível gerar o código de barras.";
     }
   }, [
     backgroundColor,
     barcodeColor,
-    barcodeData,
     barcodeType,
+    barcodeValidation,
     fontSize,
     height,
     lineWidth,
+    resolvedBarcodeValue,
     showText,
   ]);
 
-  const generateQRCode = useCallback(async () => {
-    if (!canvasRef.current || !qrData) return;
-
-    setIsGenerating(true);
+  const renderQrPreview = useCallback(async (): Promise<string | null> => {
+    if (!canvasRef.current || !effectiveQrPayload) {
+      return "Preencha os dados do QR Code para gerar a visualização.";
+    }
 
     try {
-      // Use a QR code generation library
       const QRCode = (await import("qrcode")).default;
-
       const canvas = canvasRef.current;
       const ctx = canvas.getContext("2d");
 
-      if (!ctx) return;
+      if (!ctx) {
+        return null;
+      }
 
-      // Clear canvas
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-      // Set background
       ctx.fillStyle = qrBackgroundColor;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-      // Generate QR code
-      await QRCode.toCanvas(canvas, qrData, {
+      await QRCode.toCanvas(canvas, effectiveQrPayload, {
         width: qrSize,
         margin: qrMargin,
         color: {
@@ -191,13 +280,11 @@ export default function CodigoDeBarrasGratis() {
         errorCorrectionLevel: qrErrorCorrection,
       });
 
-      // Center the QR code on the canvas
       const qrWidth = qrSize + qrMargin * 2;
       const qrHeight = qrSize + qrMargin * 2;
       const x = (canvas.width - qrWidth) / 2;
       const y = (canvas.height - qrHeight) / 2;
 
-      // Create a temporary canvas to draw the centered QR code
       const tempCanvas = document.createElement("canvas");
       tempCanvas.width = qrWidth;
       tempCanvas.height = qrHeight;
@@ -210,20 +297,68 @@ export default function CodigoDeBarrasGratis() {
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         ctx.drawImage(tempCanvas, x, y);
       }
-    } catch (error) {
-      console.error("Erro ao gerar QR code:", error);
-    } finally {
-      setIsGenerating(false);
-    }
-  }, [qrBackgroundColor, qrColor, qrData, qrErrorCorrection, qrMargin, qrSize]);
 
-  const generateCode = useCallback(() => {
-    if (generatorType === "barcode") {
-      generateBarcode();
-    } else {
-      generateQRCode();
+      return null;
+    } catch (error) {
+      return error instanceof Error
+        ? error.message
+        : "Não foi possível gerar o QR Code.";
     }
-  }, [generateBarcode, generateQRCode, generatorType]);
+  }, [
+    effectiveQrPayload,
+    qrBackgroundColor,
+    qrColor,
+    qrErrorCorrection,
+    qrMargin,
+    qrSize,
+  ]);
+
+  const refreshPreview = useCallback(async () => {
+    if (generatorType === "barcode") {
+      if (!barcodeData || !barcodeValidation.valid) {
+        return;
+      }
+
+      const error = renderBarcodePreview();
+      if (error) {
+        console.error("Erro ao gerar código de barras:", error);
+      }
+      return;
+    }
+
+    if (!effectiveQrPayload) {
+      return;
+    }
+
+    const error = await renderQrPreview();
+    if (error) {
+      console.error("Erro ao gerar QR code:", error);
+    }
+  }, [
+    barcodeData,
+    barcodeValidation.valid,
+    effectiveQrPayload,
+    generatorType,
+    renderBarcodePreview,
+    renderQrPreview,
+  ]);
+
+  const generateCode = useCallback(async () => {
+    setIsGenerating(true);
+    setGenerationError(null);
+
+    const error =
+      generatorType === "barcode"
+        ? renderBarcodePreview()
+        : await renderQrPreview();
+
+    if (error) {
+      setGenerationError(error);
+      console.error("Erro ao gerar código:", error);
+    }
+
+    setIsGenerating(false);
+  }, [generatorType, renderBarcodePreview, renderQrPreview]);
 
   const downloadCode = () => {
     if (!canvasRef.current) return;
@@ -232,8 +367,9 @@ export default function CodigoDeBarrasGratis() {
       const canvas = canvasRef.current;
       const link = document.createElement("a");
       const type = generatorType === "barcode" ? "barcode" : "qr";
-      const data = generatorType === "barcode" ? barcodeData : qrData;
-      link.download = `${type}-${data}.png`;
+      const data =
+        generatorType === "barcode" ? resolvedBarcodeValue : effectiveQrPayload;
+      link.download = buildDownloadFilename(type, data);
       link.href = canvas.toDataURL();
       link.click();
     } catch (error) {
@@ -247,15 +383,20 @@ export default function CodigoDeBarrasGratis() {
     try {
       const canvas = canvasRef.current;
       canvas.toBlob(async (blob) => {
-        if (blob) {
-          await navigator.clipboard.write([
-            new ClipboardItem({
-              "image/png": blob,
-            }),
-          ]);
+        if (!blob) {
+          setCopyFeedback("Não foi possível copiar a imagem.");
+          return;
         }
+
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            "image/png": blob,
+          }),
+        ]);
+        setCopyFeedback("Imagem copiada para a área de transferência.");
       });
     } catch (error) {
+      setCopyFeedback("Não foi possível copiar a imagem.");
       console.error("Erro ao copiar código:", error);
     }
   };
@@ -264,745 +405,1061 @@ export default function CodigoDeBarrasGratis() {
   useEffect(() => {
     if (canvasRef.current) {
       if (generatorType === "barcode") {
-        const size = SIZE_OPTIONS.find((s) => s.value === barcodeSize);
-        if (size) {
-          const [width, height] = size.dimensions.split("x").map(Number);
-          canvasRef.current.width = width;
-          canvasRef.current.height = height;
-        }
+        const { width, height } = getBarcodeCanvasDimensions(
+          barcodeSize,
+          BARCODE_SIZE_OPTIONS
+        );
+        canvasRef.current.width = width;
+        canvasRef.current.height = height;
       } else {
-        // For QR codes, use square dimensions
-        canvasRef.current.width = qrSize + 100;
-        canvasRef.current.height = qrSize + 100;
+        const { width, height } = getQrCanvasDimensions(qrSize);
+        canvasRef.current.width = width;
+        canvasRef.current.height = height;
       }
-      generateCode();
+      void refreshPreview();
     }
-  }, [barcodeSize, generateCode, generatorType, qrSize]);
+  }, [barcodeSize, generatorType, qrSize, refreshPreview]);
 
-  // Generate code when parameters change
   useEffect(() => {
-    if (
-      (generatorType === "barcode" && barcodeData) ||
-      (generatorType === "qr" && qrData)
-    ) {
-      generateCode();
+    void refreshPreview();
+  }, [refreshPreview]);
+
+  useEffect(() => {
+    if (!copyFeedback) {
+      return;
     }
-  }, [generateCode, generatorType, barcodeData, qrData]);
+
+    const timeout = window.setTimeout(() => setCopyFeedback(null), 2400);
+    return () => window.clearTimeout(timeout);
+  }, [copyFeedback]);
 
   return (
-    <main>
+    <div className="ps-landing-canvas relative min-h-screen overflow-x-hidden">
+      <div className="ps-landing-bg" aria-hidden="true">
+        <div className="ps-landing-bg-glow" />
+        <div className="ps-landing-bg-lines" />
+      </div>
       <Navbar />
-      <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-blue-50 pt-20">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          {/* Header */}
-          <div className="text-center mb-12">
-            <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent mb-4">
-              {generatorType === "barcode"
-                ? t.title
-                : "Gerador de QR Code Grátis"}
-            </h1>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              {generatorType === "barcode"
-                ? t.description
-                : "Crie QR codes profissionais para seu negócio. Suporte para URLs, texto, contatos e mais."}
-            </p>
-          </div>
 
-          {/* Generator Type Toggle */}
-          <div className="flex justify-center mb-8">
-            <div className="bg-white rounded-lg p-1 shadow-md border border-gray-200">
-              <button
-                onClick={() => setGeneratorType("barcode")}
-                className={`px-6 py-3 rounded-md font-medium transition-all duration-200 ${
-                  generatorType === "barcode"
-                    ? "bg-purple-600 text-white shadow-lg"
-                    : "text-gray-600 hover:text-purple-600 hover:bg-purple-50"
-                }`}
-              >
-                <BarChart3 className="inline-block w-5 h-5 mr-2" />
-                Código de Barras
-              </button>
-              <button
-                onClick={() => setGeneratorType("qr")}
-                className={`px-6 py-3 rounded-md font-medium transition-all duration-200 ${
-                  generatorType === "qr"
-                    ? "bg-purple-600 text-white shadow-lg"
-                    : "text-gray-600 hover:text-purple-600 hover:bg-purple-50"
-                }`}
-              >
-                <QrCode className="inline-block w-5 h-5 mr-2" />
-                QR Code
-              </button>
-            </div>
-          </div>
+      <main className="relative z-[1] pt-24 pb-20">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+          <div className="ps-panel overflow-hidden">
+            <div className="ps-panel-chrome relative flex items-center justify-between px-4 py-2.5 sm:px-5">
+              <div className="flex items-center gap-[6px]" aria-hidden="true">
+                <span className="h-[12px] w-[12px] rounded-full bg-[#e86a63] shadow-[inset_0_0_0_0.5px_rgba(0,0,0,0.12)]" />
+                <span className="h-[12px] w-[12px] rounded-full bg-[#e9b54c] shadow-[inset_0_0_0_0.5px_rgba(0,0,0,0.12)]" />
+                <span className="h-[12px] w-[12px] rounded-full bg-[#4ab96a] shadow-[inset_0_0_0_0.5px_rgba(0,0,0,0.12)]" />
+              </div>
 
-          <div className="grid lg:grid-cols-3 gap-8">
-            {/* Configuration Panel */}
-            <div className="lg:col-span-1">
-              <Card className="sticky top-24">
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <Settings className="h-5 w-5 text-purple-600" />
-                    {t.configuration.title}
-                  </CardTitle>
-                  <CardDescription>
-                    {t.configuration.description}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                  {/* Data Input */}
-                  <div className="space-y-2">
-                    <Label htmlFor="dataInput">
-                      {generatorType === "barcode"
-                        ? t.configuration.data
-                        : "Dados do QR Code"}
-                    </Label>
-                    <Input
-                      id="dataInput"
-                      value={generatorType === "barcode" ? barcodeData : qrData}
-                      onChange={(e) => {
-                        if (generatorType === "barcode") {
-                          setBarcodeData(e.target.value);
-                        } else {
-                          setQrData(e.target.value);
-                        }
-                      }}
-                      placeholder={
-                        generatorType === "barcode"
-                          ? "123456789"
-                          : "https://exemplo.com"
-                      }
-                      className="border-purple-200 focus:border-purple-500"
-                    />
-                    {generatorType === "qr" && (
-                      <p className="text-xs text-gray-500">
-                        Suporta URLs, texto, números de telefone, emails,
-                        coordenadas GPS e mais
-                      </p>
-                    )}
-                  </div>
+              <div className="absolute left-1/2 flex -translate-x-1/2 items-center gap-2">
+                <div className="flex h-4 w-4 items-center justify-center rounded bg-brand-ui-primary shadow-sm">
+                  <Box className="h-2.5 w-2.5 text-white" strokeWidth={3} />
+                </div>
+                <span className="text-[12px] font-semibold tracking-wide text-slate-600">
+                  Purple Stock · Gerador
+                </span>
+              </div>
 
-                  {/* Barcode Type - Only show for barcodes */}
-                  {generatorType === "barcode" && (
-                    <div className="space-y-2">
-                      <Label htmlFor="barcodeType">
-                        {t.configuration.type}
-                      </Label>
-                      <Select
-                        value={barcodeType}
-                        onValueChange={setBarcodeType}
-                      >
-                        <SelectTrigger className="border-purple-200 focus:border-purple-500">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {BARCODE_TYPES.map((type) => (
-                            <SelectItem key={type.value} value={type.value}>
-                              <div>
-                                <div className="font-medium">{type.label}</div>
-                                <div className="text-sm text-gray-500">
-                                  {type.description}
-                                </div>
-                              </div>
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  )}
-
-                  {/* QR Code Error Correction - Only show for QR codes */}
-                  {generatorType === "qr" && (
-                    <div className="space-y-2">
-                      <Label htmlFor="qrErrorCorrection">
-                        Correção de Erro
-                      </Label>
-                      <Select
-                        value={qrErrorCorrection}
-                        onValueChange={(value) =>
-                          setQrErrorCorrection(
-                            value as QRCodeErrorCorrectionLevel
-                          )
-                        }
-                      >
-                        <SelectTrigger className="border-purple-200 focus:border-purple-500">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {QR_ERROR_CORRECTION_LEVELS.map((level) => (
-                            <SelectItem key={level.value} value={level.value}>
-                              <div>
-                                <div className="font-medium">{level.label}</div>
-                                <div className="text-sm text-gray-500">
-                                  {level.description}
-                                </div>
-                              </div>
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  )}
-
-                  {/* Size */}
-                  <div className="space-y-2">
-                    <Label htmlFor="size">
-                      {generatorType === "barcode"
-                        ? t.configuration.size
-                        : "Tamanho"}
-                    </Label>
-                    {generatorType === "barcode" ? (
-                      <Select
-                        value={barcodeSize}
-                        onValueChange={setBarcodeSize}
-                      >
-                        <SelectTrigger className="border-purple-200 focus:border-purple-500">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {SIZE_OPTIONS.map((size) => (
-                            <SelectItem key={size.value} value={size.value}>
-                              <div>
-                                <div className="font-medium">{size.label}</div>
-                                <div className="text-sm text-gray-500">
-                                  {size.dimensions}
-                                </div>
-                              </div>
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <div className="space-y-2">
-                        <Input
-                          type="range"
-                          id="qrSize"
-                          min="128"
-                          max="512"
-                          step="32"
-                          value={qrSize}
-                          onChange={(e) => setQrSize(Number(e.target.value))}
-                          className="w-full"
-                        />
-                        <div className="text-sm text-gray-500">
-                          {qrSize}x{qrSize}px
-                        </div>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Advanced Options - Only show for barcodes */}
-                  {generatorType === "barcode" && (
-                    <div className="space-y-4">
-                      <div className="space-y-2">
-                        <Label htmlFor="lineWidth">Largura da Linha</Label>
-                        <Input
-                          type="range"
-                          id="lineWidth"
-                          min="1"
-                          max="5"
-                          step="0.5"
-                          value={lineWidth}
-                          onChange={(e) => setLineWidth(Number(e.target.value))}
-                          className="w-full"
-                        />
-                        <div className="text-sm text-gray-500">
-                          {lineWidth}px
-                        </div>
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="height">Altura</Label>
-                        <Input
-                          type="range"
-                          id="height"
-                          min="50"
-                          max="200"
-                          step="10"
-                          value={height}
-                          onChange={(e) => setHeight(Number(e.target.value))}
-                          className="w-full"
-                        />
-                        <div className="text-sm text-gray-500">{height}px</div>
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="fontSize">Tamanho da Fonte</Label>
-                        <Input
-                          type="range"
-                          id="fontSize"
-                          min="12"
-                          max="32"
-                          step="2"
-                          value={fontSize}
-                          onChange={(e) => setFontSize(Number(e.target.value))}
-                          className="w-full"
-                        />
-                        <div className="text-sm text-gray-500">
-                          {fontSize}px
-                        </div>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* QR Code Margin - Only show for QR codes */}
-                  {generatorType === "qr" && (
-                    <div className="space-y-2">
-                      <Label htmlFor="qrMargin">Margem</Label>
-                      <Input
-                        type="range"
-                        id="qrMargin"
-                        min="0"
-                        max="8"
-                        step="1"
-                        value={qrMargin}
-                        onChange={(e) => setQrMargin(Number(e.target.value))}
-                        className="w-full"
-                      />
-                      <div className="text-sm text-gray-500">
-                        {qrMargin} módulos
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Colors */}
-                  <div className="grid grid-cols-2 gap-4">
-                    <div className="space-y-2">
-                      <Label htmlFor="codeColor">
-                        {generatorType === "barcode"
-                          ? t.configuration.barcodeColor
-                          : "Cor do QR Code"}
-                      </Label>
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="color"
-                          id="codeColor"
-                          value={
-                            generatorType === "barcode" ? barcodeColor : qrColor
-                          }
-                          onChange={(e) => {
-                            if (generatorType === "barcode") {
-                              setBarcodeColor(e.target.value);
-                            } else {
-                              setQrColor(e.target.value);
-                            }
-                          }}
-                          className="w-10 h-10 rounded border border-gray-300 cursor-pointer"
-                        />
-                        <Input
-                          value={
-                            generatorType === "barcode" ? barcodeColor : qrColor
-                          }
-                          onChange={(e) => {
-                            if (generatorType === "barcode") {
-                              setBarcodeColor(e.target.value);
-                            } else {
-                              setQrColor(e.target.value);
-                            }
-                          }}
-                          className="flex-1 border-purple-200 focus:border-purple-500"
-                        />
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="backgroundColor">
-                        {t.configuration.backgroundColor}
-                      </Label>
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="color"
-                          id="backgroundColor"
-                          value={
-                            generatorType === "barcode"
-                              ? backgroundColor
-                              : qrBackgroundColor
-                          }
-                          onChange={(e) => {
-                            if (generatorType === "barcode") {
-                              setBackgroundColor(e.target.value);
-                            } else {
-                              setQrBackgroundColor(e.target.value);
-                            }
-                          }}
-                          className="w-10 h-10 rounded border border-gray-300 cursor-pointer"
-                        />
-                        <Input
-                          value={
-                            generatorType === "barcode"
-                              ? backgroundColor
-                              : qrBackgroundColor
-                          }
-                          onChange={(e) => {
-                            if (generatorType === "barcode") {
-                              setBackgroundColor(e.target.value);
-                            } else {
-                              setQrBackgroundColor(e.target.value);
-                            }
-                          }}
-                          className="flex-1 border-purple-200 focus:border-purple-500"
-                        />
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Options - Only show text option for barcodes */}
-                  {generatorType === "barcode" && (
-                    <div className="space-y-3">
-                      <div className="flex items-center space-x-2">
-                        <input
-                          type="checkbox"
-                          id="showText"
-                          checked={showText}
-                          onChange={(e) => setShowText(e.target.checked)}
-                          className="rounded border-purple-300 text-purple-600 focus:ring-purple-500"
-                        />
-                        <Label htmlFor="showText">
-                          {t.configuration.showText}
-                        </Label>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Action Buttons */}
-                  <div className="space-y-3 pt-4">
-                    <Button
-                      onClick={generateCode}
-                      disabled={isGenerating}
-                      className="w-full bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700"
-                    >
-                      <RefreshCw
-                        className={`h-4 w-4 mr-2 ${isGenerating ? "animate-spin" : ""}`}
-                      />
-                      {isGenerating ? "Gerando..." : "Regenerar"}
-                    </Button>
-                    <Button
-                      onClick={downloadCode}
-                      className="w-full bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800"
-                    >
-                      <Download className="h-4 w-4 mr-2" />
-                      {t.actions.download}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      onClick={copyCode}
-                      className="w-full border-purple-200 hover:border-purple-300 hover:bg-purple-50"
-                    >
-                      <Copy className="h-4 w-4 mr-2" />
-                      Copiar
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
+              <span className="text-[10px] font-medium text-slate-400">
+                {language === "pt"
+                  ? "Ferramenta gratuita"
+                  : language === "fr"
+                    ? "Outil gratuit"
+                    : "Free tool"}
+              </span>
             </div>
 
-            {/* Preview and Information */}
-            <div className="lg:col-span-2 space-y-8">
-              {/* Code Preview */}
-              <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    {generatorType === "barcode" ? (
-                      <BarChart3 className="h-5 w-5 text-purple-600" />
-                    ) : (
-                      <QrCode className="h-5 w-5 text-purple-600" />
-                    )}
-                    {t.preview.title}
-                  </CardTitle>
-                  <CardDescription>{t.preview.description}</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex flex-col items-center space-y-6">
-                    <div className="bg-white p-8 rounded-lg border-2 border-dashed border-purple-200 min-h-[300px] flex items-center justify-center">
-                      {(generatorType === "barcode" && barcodeData) ||
-                      (generatorType === "qr" && qrData) ? (
-                        <canvas
-                          ref={canvasRef}
-                          className="max-w-full h-auto border border-gray-200 rounded-lg"
-                          style={{
-                            backgroundColor:
-                              generatorType === "barcode"
-                                ? backgroundColor
-                                : qrBackgroundColor,
-                          }}
-                        />
-                      ) : (
-                        <div className="text-center text-gray-500">
-                          {generatorType === "barcode" ? (
-                            <BarChart3 className="h-16 w-16 mx-auto mb-2 text-gray-300" />
-                          ) : (
-                            <QrCode className="h-16 w-16 mx-auto mb-2 text-gray-300" />
+            <div className="p-6 md:p-10">
+              <div className="mb-12 text-center">
+                <div className="ps-badge-violet mb-4 inline-flex items-center px-4 py-2 text-sm normal-case tracking-normal">
+                  {generatorType === "barcode" ? (
+                    <BarChart3 className="mr-2 h-4 w-4" />
+                  ) : (
+                    <QrCode className="mr-2 h-4 w-4" />
+                  )}
+                  {language === "pt"
+                    ? "Ferramenta gratuita"
+                    : language === "fr"
+                      ? "Outil gratuit"
+                      : "Free tool"}
+                </div>
+                <h1 className="ps-display mb-4 text-4xl md:text-5xl">
+                  {generatorType === "barcode"
+                    ? t.title
+                    : "Gerador de QR Code Grátis"}
+                </h1>
+                <p className="ps-lead mx-auto max-w-3xl text-xl">
+                  {generatorType === "barcode"
+                    ? t.description
+                    : "Crie QR codes profissionais para seu negócio. Suporte para URLs, texto, contatos e mais."}
+                </p>
+              </div>
+
+              <div className="mb-8 flex justify-center">
+                <div className="ps-section-surface inline-flex rounded-lg p-1">
+                  <button
+                    onClick={() => setGeneratorType("barcode")}
+                    className={`rounded-md px-6 py-3 font-medium transition-all duration-200 ${
+                      generatorType === "barcode"
+                        ? "bg-brand-ui-primary text-white shadow-sm"
+                        : "text-slate-600 hover:bg-white hover:text-brand-ui-primary"
+                    }`}
+                  >
+                    <BarChart3 className="mr-2 inline-block h-5 w-5" />
+                    Código de Barras
+                  </button>
+                  <button
+                    onClick={() => setGeneratorType("qr")}
+                    className={`rounded-md px-6 py-3 font-medium transition-all duration-200 ${
+                      generatorType === "qr"
+                        ? "bg-brand-ui-primary text-white shadow-sm"
+                        : "text-slate-600 hover:bg-white hover:text-brand-ui-primary"
+                    }`}
+                  >
+                    <QrCode className="mr-2 inline-block h-5 w-5" />
+                    QR Code
+                  </button>
+                </div>
+              </div>
+
+              <div className="grid gap-8 lg:grid-cols-3">
+                {/* Configuration Panel */}
+                <div className="lg:col-span-1">
+                  <Card className="ps-card sticky top-24 border-brand-border-soft shadow-none">
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2 text-lg font-semibold text-brand-ink">
+                        <Settings className="h-5 w-5 text-brand-ui-primary" />
+                        {t.configuration.title}
+                      </CardTitle>
+                      <CardDescription>
+                        {t.configuration.description}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-6">
+                      {generatorType === "barcode" ? (
+                        <div className="space-y-2">
+                          <Label htmlFor="dataInput">
+                            {t.configuration.data}
+                          </Label>
+                          <Input
+                            id="dataInput"
+                            value={barcodeData}
+                            onChange={(e) => {
+                              setGenerationError(null);
+                              setBarcodeData(
+                                sanitizeBarcodeInput(
+                                  barcodeType as BarcodeFormat,
+                                  e.target.value
+                                )
+                              );
+                            }}
+                            placeholder="123456789"
+                            className="border-brand-border-soft focus:border-brand-ui-primary"
+                          />
+                          {!barcodeValidation.valid && (
+                            <p className="text-xs text-red-600">
+                              {barcodeValidation.error}
+                            </p>
                           )}
-                          <p>{t.preview.enterData}</p>
+                          {ean13Suggestion && (
+                            <button
+                              type="button"
+                              className="text-xs font-medium text-brand-link-blue hover:underline"
+                              onClick={() =>
+                                setBarcodeData(
+                                  `${barcodeData}${ean13Suggestion}`
+                                )
+                              }
+                            >
+                              Completar dígito verificador EAN-13 (
+                              {ean13Suggestion})
+                            </button>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="space-y-4">
+                          <div className="space-y-2">
+                            <Label htmlFor="qrPreset">Tipo de conteúdo</Label>
+                            <Select
+                              value={qrPreset}
+                              onValueChange={(value) =>
+                                handleQrPresetChange(value as QrPreset)
+                              }
+                            >
+                              <SelectTrigger className="border-brand-border-soft focus:border-brand-ui-primary">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {QR_PRESETS.map((preset) => (
+                                  <SelectItem
+                                    key={preset.value}
+                                    value={preset.value}
+                                  >
+                                    {preset.label}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+
+                          {qrPreset === "url" && (
+                            <div className="space-y-2">
+                              <Label htmlFor="qrUrl">URL</Label>
+                              <Input
+                                id="qrUrl"
+                                value={qrFields.url ?? ""}
+                                onChange={(e) =>
+                                  updateQrField("url", e.target.value)
+                                }
+                                placeholder="purplestock.com.br"
+                                className="border-brand-border-soft focus:border-brand-ui-primary"
+                              />
+                            </div>
+                          )}
+
+                          {qrPreset === "text" && (
+                            <div className="space-y-2">
+                              <Label htmlFor="qrText">Texto</Label>
+                              <Input
+                                id="qrText"
+                                value={qrFields.text ?? ""}
+                                onChange={(e) =>
+                                  updateQrField("text", e.target.value)
+                                }
+                                placeholder="Mensagem ou identificador"
+                                className="border-brand-border-soft focus:border-brand-ui-primary"
+                              />
+                            </div>
+                          )}
+
+                          {qrPreset === "email" && (
+                            <div className="space-y-3">
+                              <div className="space-y-2">
+                                <Label htmlFor="qrEmail">Email</Label>
+                                <Input
+                                  id="qrEmail"
+                                  value={qrFields.email ?? ""}
+                                  onChange={(e) =>
+                                    updateQrField("email", e.target.value)
+                                  }
+                                  placeholder="contato@empresa.com"
+                                  className="border-brand-border-soft focus:border-brand-ui-primary"
+                                />
+                              </div>
+                              <div className="space-y-2">
+                                <Label htmlFor="qrSubject">Assunto</Label>
+                                <Input
+                                  id="qrSubject"
+                                  value={qrFields.subject ?? ""}
+                                  onChange={(e) =>
+                                    updateQrField("subject", e.target.value)
+                                  }
+                                  placeholder="Opcional"
+                                  className="border-brand-border-soft focus:border-brand-ui-primary"
+                                />
+                              </div>
+                              <div className="space-y-2">
+                                <Label htmlFor="qrBody">Mensagem</Label>
+                                <Input
+                                  id="qrBody"
+                                  value={qrFields.body ?? ""}
+                                  onChange={(e) =>
+                                    updateQrField("body", e.target.value)
+                                  }
+                                  placeholder="Opcional"
+                                  className="border-brand-border-soft focus:border-brand-ui-primary"
+                                />
+                              </div>
+                            </div>
+                          )}
+
+                          {(qrPreset === "phone" || qrPreset === "sms") && (
+                            <div className="space-y-2">
+                              <Label htmlFor="qrPhone">Telefone</Label>
+                              <Input
+                                id="qrPhone"
+                                value={qrFields.phone ?? ""}
+                                onChange={(e) =>
+                                  updateQrField("phone", e.target.value)
+                                }
+                                placeholder="+55 11 99999-0000"
+                                className="border-brand-border-soft focus:border-brand-ui-primary"
+                              />
+                            </div>
+                          )}
+
+                          {qrPreset === "sms" && (
+                            <div className="space-y-2">
+                              <Label htmlFor="qrMessage">Mensagem SMS</Label>
+                              <Input
+                                id="qrMessage"
+                                value={qrFields.message ?? ""}
+                                onChange={(e) =>
+                                  updateQrField("message", e.target.value)
+                                }
+                                placeholder="Texto pré-preenchido"
+                                className="border-brand-border-soft focus:border-brand-ui-primary"
+                              />
+                            </div>
+                          )}
+
+                          {qrPreset === "wifi" && (
+                            <div className="space-y-3">
+                              <div className="space-y-2">
+                                <Label htmlFor="qrSsid">
+                                  Nome da rede (SSID)
+                                </Label>
+                                <Input
+                                  id="qrSsid"
+                                  value={qrFields.ssid ?? ""}
+                                  onChange={(e) =>
+                                    updateQrField("ssid", e.target.value)
+                                  }
+                                  placeholder="WiFi da loja"
+                                  className="border-brand-border-soft focus:border-brand-ui-primary"
+                                />
+                              </div>
+                              <div className="space-y-2">
+                                <Label htmlFor="qrPassword">Senha</Label>
+                                <Input
+                                  id="qrPassword"
+                                  type="password"
+                                  value={qrFields.password ?? ""}
+                                  onChange={(e) =>
+                                    updateQrField("password", e.target.value)
+                                  }
+                                  placeholder="Senha da rede"
+                                  className="border-brand-border-soft focus:border-brand-ui-primary"
+                                />
+                              </div>
+                              <div className="space-y-2">
+                                <Label htmlFor="qrSecurity">Segurança</Label>
+                                <Select
+                                  value={qrFields.security ?? "WPA"}
+                                  onValueChange={(value) =>
+                                    updateQrField(
+                                      "security",
+                                      value as QrPresetInput["security"]
+                                    )
+                                  }
+                                >
+                                  <SelectTrigger className="border-brand-border-soft focus:border-brand-ui-primary">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    <SelectItem value="WPA">
+                                      WPA / WPA2
+                                    </SelectItem>
+                                    <SelectItem value="WEP">WEP</SelectItem>
+                                    <SelectItem value="nopass">
+                                      Aberta
+                                    </SelectItem>
+                                  </SelectContent>
+                                </Select>
+                              </div>
+                            </div>
+                          )}
+
+                          {effectiveQrPayload && (
+                            <p className="rounded-lg border border-brand-border-soft bg-brand-surface-soft/70 px-3 py-2 text-xs text-slate-600 break-all">
+                              <span className="font-medium text-brand-ink">
+                                Conteúdo gerado:
+                              </span>{" "}
+                              {effectiveQrPayload}
+                            </p>
+                          )}
                         </div>
                       )}
-                    </div>
 
-                    {((generatorType === "barcode" && barcodeData) ||
-                      (generatorType === "qr" && qrData)) && (
-                      <div className="text-center space-y-2">
-                        <p className="text-sm text-gray-600">
-                          <strong>Tipo:</strong>{" "}
+                      {/* Barcode Type - Only show for barcodes */}
+                      {generatorType === "barcode" && (
+                        <div className="space-y-2">
+                          <Label htmlFor="barcodeType">
+                            {t.configuration.type}
+                          </Label>
+                          <Select
+                            value={barcodeType}
+                            onValueChange={(value) => {
+                              setBarcodeType(value);
+                              setBarcodeData((current) =>
+                                sanitizeBarcodeInput(
+                                  value as BarcodeFormat,
+                                  current
+                                )
+                              );
+                              setGenerationError(null);
+                            }}
+                          >
+                            <SelectTrigger className="border-brand-border-soft focus:border-brand-ui-primary">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {BARCODE_TYPES.map((type) => (
+                                <SelectItem key={type.value} value={type.value}>
+                                  <div>
+                                    <div className="font-medium">
+                                      {type.label}
+                                    </div>
+                                    <div className="text-sm text-slate-500">
+                                      {type.description}
+                                    </div>
+                                  </div>
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      )}
+
+                      {/* QR Code Error Correction - Only show for QR codes */}
+                      {generatorType === "qr" && (
+                        <div className="space-y-2">
+                          <Label htmlFor="qrErrorCorrection">
+                            Correção de Erro
+                          </Label>
+                          <Select
+                            value={qrErrorCorrection}
+                            onValueChange={(value) =>
+                              setQrErrorCorrection(
+                                value as QRCodeErrorCorrectionLevel
+                              )
+                            }
+                          >
+                            <SelectTrigger className="border-brand-border-soft focus:border-brand-ui-primary">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {QR_ERROR_CORRECTION_LEVELS.map((level) => (
+                                <SelectItem
+                                  key={level.value}
+                                  value={level.value}
+                                >
+                                  <div>
+                                    <div className="font-medium">
+                                      {level.label}
+                                    </div>
+                                    <div className="text-sm text-slate-500">
+                                      {level.description}
+                                    </div>
+                                  </div>
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      )}
+
+                      {/* Size */}
+                      <div className="space-y-2">
+                        <Label htmlFor="size">
                           {generatorType === "barcode"
-                            ? "Código de Barras"
-                            : "QR Code"}
-                        </p>
-                        <p className="text-sm text-gray-600">
-                          <strong>Dados:</strong>{" "}
-                          {generatorType === "barcode" ? barcodeData : qrData}
-                        </p>
+                            ? t.configuration.size
+                            : "Tamanho"}
+                        </Label>
                         {generatorType === "barcode" ? (
-                          <p className="text-sm text-gray-600">
-                            <strong>Formato:</strong>{" "}
-                            {
-                              BARCODE_TYPES.find((t) => t.value === barcodeType)
-                                ?.label
-                            }
-                          </p>
+                          <Select
+                            value={barcodeSize}
+                            onValueChange={setBarcodeSize}
+                          >
+                            <SelectTrigger className="border-brand-border-soft focus:border-brand-ui-primary">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {BARCODE_SIZE_OPTIONS.map((size) => (
+                                <SelectItem key={size.value} value={size.value}>
+                                  <div>
+                                    <div className="font-medium">
+                                      {size.label}
+                                    </div>
+                                    <div className="text-sm text-slate-500">
+                                      {size.dimensions}
+                                    </div>
+                                  </div>
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
                         ) : (
-                          <p className="text-sm text-gray-600">
-                            <strong>Tamanho:</strong> {qrSize}x{qrSize}px
-                          </p>
+                          <div className="space-y-2">
+                            <Input
+                              type="range"
+                              id="qrSize"
+                              min="128"
+                              max="512"
+                              step="32"
+                              value={qrSize}
+                              onChange={(e) =>
+                                setQrSize(Number(e.target.value))
+                              }
+                              className="w-full"
+                            />
+                            <div className="text-sm text-slate-500">
+                              {qrSize}x{qrSize}px
+                            </div>
+                          </div>
                         )}
-                        {generatorType === "barcode" && (
-                          <p className="text-sm text-gray-600">
-                            <strong>Dimensões:</strong>{" "}
-                            {
-                              SIZE_OPTIONS.find((s) => s.value === barcodeSize)
-                                ?.dimensions
+                      </div>
+
+                      {/* Advanced Options - Only show for barcodes */}
+                      {generatorType === "barcode" && (
+                        <div className="space-y-4">
+                          <div className="space-y-2">
+                            <Label htmlFor="lineWidth">Largura da Linha</Label>
+                            <Input
+                              type="range"
+                              id="lineWidth"
+                              min="1"
+                              max="5"
+                              step="0.5"
+                              value={lineWidth}
+                              onChange={(e) =>
+                                setLineWidth(Number(e.target.value))
+                              }
+                              className="w-full"
+                            />
+                            <div className="text-sm text-slate-500">
+                              {lineWidth}px
+                            </div>
+                          </div>
+
+                          <div className="space-y-2">
+                            <Label htmlFor="height">Altura</Label>
+                            <Input
+                              type="range"
+                              id="height"
+                              min="50"
+                              max="200"
+                              step="10"
+                              value={height}
+                              onChange={(e) =>
+                                setHeight(Number(e.target.value))
+                              }
+                              className="w-full"
+                            />
+                            <div className="text-sm text-slate-500">
+                              {height}px
+                            </div>
+                          </div>
+
+                          <div className="space-y-2">
+                            <Label htmlFor="fontSize">Tamanho da Fonte</Label>
+                            <Input
+                              type="range"
+                              id="fontSize"
+                              min="12"
+                              max="32"
+                              step="2"
+                              value={fontSize}
+                              onChange={(e) =>
+                                setFontSize(Number(e.target.value))
+                              }
+                              className="w-full"
+                            />
+                            <div className="text-sm text-slate-500">
+                              {fontSize}px
+                            </div>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* QR Code Margin - Only show for QR codes */}
+                      {generatorType === "qr" && (
+                        <div className="space-y-2">
+                          <Label htmlFor="qrMargin">Margem</Label>
+                          <Input
+                            type="range"
+                            id="qrMargin"
+                            min="0"
+                            max="8"
+                            step="1"
+                            value={qrMargin}
+                            onChange={(e) =>
+                              setQrMargin(Number(e.target.value))
                             }
-                          </p>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
-
-              {/* Information Tabs */}
-              <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <Info className="h-5 w-5 text-purple-600" />
-                    {t.information.title}
-                  </CardTitle>
-                  <CardDescription>{t.information.description}</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <Tabs defaultValue="formats" className="w-full">
-                    <TabsList className="grid w-full grid-cols-3">
-                      <TabsTrigger value="formats">
-                        {generatorType === "barcode"
-                          ? "Formatos"
-                          : "Tipos de QR"}
-                      </TabsTrigger>
-                      <TabsTrigger value="usage">
-                        {t.information.usage.title}
-                      </TabsTrigger>
-                      <TabsTrigger value="tips">
-                        {t.information.tips.title}
-                      </TabsTrigger>
-                    </TabsList>
-
-                    <TabsContent value="formats" className="mt-6">
-                      <div className="space-y-4">
-                        {generatorType === "barcode"
-                          ? // Barcode formats
-                            BARCODE_TYPES.map((type) => (
-                              <div
-                                key={type.value}
-                                className="flex items-start gap-3 p-3 rounded-lg border border-gray-100"
-                              >
-                                <div className="w-2 h-2 bg-purple-500 rounded-full mt-2 flex-shrink-0"></div>
-                                <div>
-                                  <h4 className="font-medium text-gray-900">
-                                    {type.label}
-                                  </h4>
-                                  <p className="text-sm text-gray-600">
-                                    {type.description}
-                                  </p>
-                                  <p className="text-xs text-gray-500 mt-1">
-                                    {t.information.formats[
-                                      type.value as keyof typeof t.information.formats
-                                    ] ?? t.information.formats.default}
-                                  </p>
-                                </div>
-                              </div>
-                            ))
-                          : // QR Code types
-                            [
-                              {
-                                title: "URL",
-                                description:
-                                  "Links para websites, redes sociais e aplicativos",
-                              },
-                              {
-                                title: "Texto",
-                                description:
-                                  "Mensagens, notas e informações estáticas",
-                              },
-                              {
-                                title: "Contato (vCard)",
-                                description:
-                                  "Informações de contato para agenda",
-                              },
-                              {
-                                title: "Email",
-                                description:
-                                  "Endereços de email com assunto e corpo",
-                              },
-                              {
-                                title: "Telefone",
-                                description:
-                                  "Números de telefone para ligação direta",
-                              },
-                              {
-                                title: "SMS",
-                                description:
-                                  "Mensagens de texto pré-formatadas",
-                              },
-                              {
-                                title: "WiFi",
-                                description: "Configurações de rede WiFi",
-                              },
-                              {
-                                title: "Localização",
-                                description: "Coordenadas GPS e endereços",
-                              },
-                            ].map((type, index) => (
-                              <div
-                                key={index}
-                                className="flex items-start gap-3 p-3 rounded-lg border border-gray-100"
-                              >
-                                <div className="w-2 h-2 bg-purple-500 rounded-full mt-2 flex-shrink-0"></div>
-                                <div>
-                                  <h4 className="font-medium text-gray-900">
-                                    {type.title}
-                                  </h4>
-                                  <p className="text-sm text-gray-600">
-                                    {type.description}
-                                  </p>
-                                </div>
-                              </div>
-                            ))}
-                      </div>
-                    </TabsContent>
-
-                    <TabsContent value="usage" className="mt-6">
-                      <div className="space-y-4">
-                        <div className="grid md:grid-cols-2 gap-4">
-                          <div className="p-4 rounded-lg bg-purple-50 border border-purple-200">
-                            <h4 className="font-medium text-purple-900 mb-2">
-                              {t.information.usage.retail.title}
-                            </h4>
-                            <p className="text-sm text-purple-700">
-                              {t.information.usage.retail.description}
-                            </p>
+                            className="w-full"
+                          />
+                          <div className="text-sm text-slate-500">
+                            {qrMargin} módulos
                           </div>
-                          <div className="p-4 rounded-lg bg-blue-50 border border-blue-200">
-                            <h4 className="font-medium text-blue-900 mb-2">
-                              {t.information.usage.logistics.title}
-                            </h4>
-                            <p className="text-sm text-blue-700">
-                              {t.information.usage.logistics.description}
-                            </p>
+                        </div>
+                      )}
+
+                      {/* Colors */}
+                      <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                          <Label htmlFor="codeColor">
+                            {generatorType === "barcode"
+                              ? t.configuration.barcodeColor
+                              : "Cor do QR Code"}
+                          </Label>
+                          <div className="flex items-center gap-2">
+                            <input
+                              type="color"
+                              id="codeColor"
+                              value={
+                                generatorType === "barcode"
+                                  ? barcodeColor
+                                  : qrColor
+                              }
+                              onChange={(e) => {
+                                if (generatorType === "barcode") {
+                                  setBarcodeColor(e.target.value);
+                                } else {
+                                  setQrColor(e.target.value);
+                                }
+                              }}
+                              className="w-10 h-10 rounded border border-brand-border-soft cursor-pointer"
+                            />
+                            <Input
+                              value={
+                                generatorType === "barcode"
+                                  ? barcodeColor
+                                  : qrColor
+                              }
+                              onChange={(e) => {
+                                if (generatorType === "barcode") {
+                                  setBarcodeColor(e.target.value);
+                                } else {
+                                  setQrColor(e.target.value);
+                                }
+                              }}
+                              className="flex-1 border-brand-border-soft focus:border-brand-ui-primary"
+                            />
                           </div>
-                          <div className="p-4 rounded-lg bg-green-50 border border-green-200">
-                            <h4 className="font-medium text-green-900 mb-2">
-                              {t.information.usage.healthcare.title}
-                            </h4>
-                            <p className="text-sm text-green-700">
-                              {t.information.usage.healthcare.description}
-                            </p>
-                          </div>
-                          <div className="p-4 rounded-lg bg-orange-50 border border-orange-200">
-                            <h4 className="font-medium text-orange-900 mb-2">
-                              {t.information.usage.manufacturing.title}
-                            </h4>
-                            <p className="text-sm text-orange-700">
-                              {t.information.usage.manufacturing.description}
-                            </p>
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor="backgroundColor">
+                            {t.configuration.backgroundColor}
+                          </Label>
+                          <div className="flex items-center gap-2">
+                            <input
+                              type="color"
+                              id="backgroundColor"
+                              value={
+                                generatorType === "barcode"
+                                  ? backgroundColor
+                                  : qrBackgroundColor
+                              }
+                              onChange={(e) => {
+                                if (generatorType === "barcode") {
+                                  setBackgroundColor(e.target.value);
+                                } else {
+                                  setQrBackgroundColor(e.target.value);
+                                }
+                              }}
+                              className="w-10 h-10 rounded border border-brand-border-soft cursor-pointer"
+                            />
+                            <Input
+                              value={
+                                generatorType === "barcode"
+                                  ? backgroundColor
+                                  : qrBackgroundColor
+                              }
+                              onChange={(e) => {
+                                if (generatorType === "barcode") {
+                                  setBackgroundColor(e.target.value);
+                                } else {
+                                  setQrBackgroundColor(e.target.value);
+                                }
+                              }}
+                              className="flex-1 border-brand-border-soft focus:border-brand-ui-primary"
+                            />
                           </div>
                         </div>
                       </div>
-                    </TabsContent>
 
-                    <TabsContent value="tips" className="mt-6">
-                      <div className="space-y-4">
-                        {generatorType === "barcode"
-                          ? // Barcode tips
-                            t.information.tips.items.map(
-                              (
-                                tip: { title: string; description: string },
-                                index: number
-                              ) => (
-                                <div
-                                  key={index}
-                                  className="flex items-start gap-3 p-3 rounded-lg border border-gray-100"
-                                >
-                                  <div className="w-6 h-6 bg-purple-100 text-purple-600 rounded-full flex items-center justify-center text-sm font-medium flex-shrink-0">
-                                    {index + 1}
-                                  </div>
-                                  <div>
-                                    <h4 className="font-medium text-gray-900">
-                                      {tip.title}
-                                    </h4>
-                                    <p className="text-sm text-gray-600">
-                                      {tip.description}
-                                    </p>
-                                  </div>
-                                </div>
-                              )
-                            )
-                          : // QR Code tips
-                            [
-                              {
-                                title: "Escolha o tamanho correto",
-                                description:
-                                  "Use tamanhos maiores para impressão e menores para uso digital",
-                              },
-                              {
-                                title: "Configure a correção de erro",
-                                description:
-                                  "Use correção alta (H) para impressão e baixa (L) para uso digital",
-                              },
-                              {
-                                title: "Teste antes de usar",
-                                description:
-                                  "Sempre teste o QR code com diferentes leitores antes da implementação",
-                              },
-                              {
-                                title: "Mantenha contraste",
-                                description:
-                                  "Use cores contrastantes para melhor legibilidade",
-                              },
-                            ].map((tip, index) => (
-                              <div
-                                key={index}
-                                className="flex items-start gap-3 p-3 rounded-lg border border-gray-100"
-                              >
-                                <div className="w-6 h-6 bg-purple-100 text-purple-600 rounded-full flex items-center justify-center text-sm font-medium flex-shrink-0">
-                                  {index + 1}
-                                </div>
-                                <div>
-                                  <h4 className="font-medium text-gray-900">
-                                    {tip.title}
-                                  </h4>
-                                  <p className="text-sm text-gray-600">
-                                    {tip.description}
-                                  </p>
-                                </div>
-                              </div>
-                            ))}
+                      {/* Options - Only show text option for barcodes */}
+                      {generatorType === "barcode" && (
+                        <div className="space-y-3">
+                          <div className="flex items-center space-x-2">
+                            <input
+                              type="checkbox"
+                              id="showText"
+                              checked={showText}
+                              onChange={(e) => setShowText(e.target.checked)}
+                              className="rounded border-brand-border-soft text-brand-ui-primary focus:ring-brand-ui-primary"
+                            />
+                            <Label htmlFor="showText">
+                              {t.configuration.showText}
+                            </Label>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Action Buttons */}
+                      <div className="space-y-3 pt-4">
+                        {generationError && (
+                          <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                            {generationError}
+                          </p>
+                        )}
+
+                        <Button
+                          onClick={generateCode}
+                          disabled={
+                            isGenerating ||
+                            (generatorType === "barcode" &&
+                              !barcodeValidation.valid)
+                          }
+                          variant="outline"
+                          className="ps-btn-outline w-full"
+                        >
+                          <RefreshCw
+                            className={`mr-2 h-4 w-4 ${isGenerating ? "animate-spin" : ""}`}
+                          />
+                          {isGenerating ? "Gerando..." : "Regenerar"}
+                        </Button>
+                        <Button
+                          onClick={downloadCode}
+                          className="ps-btn-primary w-full"
+                        >
+                          <Download className="mr-2 h-4 w-4" />
+                          {t.actions.download}
+                        </Button>
+                        <Button
+                          variant="outline"
+                          onClick={copyCode}
+                          className="ps-btn-outline w-full"
+                        >
+                          <Copy className="h-4 w-4 mr-2" />
+                          Copiar
+                        </Button>
+                        {copyFeedback && (
+                          <p className="text-center text-xs text-emerald-700">
+                            {copyFeedback}
+                          </p>
+                        )}
                       </div>
-                    </TabsContent>
-                  </Tabs>
-                </CardContent>
-              </Card>
+                    </CardContent>
+                  </Card>
+                </div>
+
+                {/* Preview and Information */}
+                <div className="lg:col-span-2 space-y-8">
+                  {/* Code Preview */}
+                  <Card className="ps-card border-brand-border-soft shadow-none">
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2 text-lg font-semibold text-brand-ink">
+                        {generatorType === "barcode" ? (
+                          <BarChart3 className="h-5 w-5 text-brand-ui-primary" />
+                        ) : (
+                          <QrCode className="h-5 w-5 text-brand-ui-primary" />
+                        )}
+                        {t.preview.title}
+                      </CardTitle>
+                      <CardDescription>{t.preview.description}</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="flex flex-col items-center space-y-6">
+                        <div className="flex min-h-[300px] items-center justify-center rounded-lg border-2 border-dashed border-brand-border-soft bg-brand-surface-soft/60 p-8">
+                          {(generatorType === "barcode" &&
+                            barcodeData &&
+                            barcodeValidation.valid) ||
+                          (generatorType === "qr" && effectiveQrPayload) ? (
+                            <canvas
+                              ref={canvasRef}
+                              className="h-auto max-w-full rounded-lg border border-brand-border-soft"
+                              style={{
+                                backgroundColor:
+                                  generatorType === "barcode"
+                                    ? backgroundColor
+                                    : qrBackgroundColor,
+                              }}
+                            />
+                          ) : (
+                            <div className="text-center text-slate-500">
+                              {generatorType === "barcode" ? (
+                                <BarChart3 className="mx-auto mb-2 h-16 w-16 text-slate-300" />
+                              ) : (
+                                <QrCode className="mx-auto mb-2 h-16 w-16 text-slate-300" />
+                              )}
+                              <p>{t.preview.enterData}</p>
+                            </div>
+                          )}
+                        </div>
+
+                        {((generatorType === "barcode" &&
+                          barcodeData &&
+                          barcodeValidation.valid) ||
+                          (generatorType === "qr" && effectiveQrPayload)) && (
+                          <div className="space-y-2 text-center">
+                            <p className="text-sm text-slate-600">
+                              <strong>Tipo:</strong>{" "}
+                              {generatorType === "barcode"
+                                ? "Código de Barras"
+                                : "QR Code"}
+                            </p>
+                            <p className="text-sm text-slate-600">
+                              <strong>Dados:</strong>{" "}
+                              {generatorType === "barcode"
+                                ? resolvedBarcodeValue
+                                : effectiveQrPayload}
+                            </p>
+                            {generatorType === "barcode" ? (
+                              <p className="text-sm text-slate-600">
+                                <strong>Formato:</strong>{" "}
+                                {
+                                  BARCODE_TYPES.find(
+                                    (t) => t.value === barcodeType
+                                  )?.label
+                                }
+                              </p>
+                            ) : (
+                              <p className="text-sm text-slate-600">
+                                <strong>Tamanho:</strong> {qrSize}x{qrSize}px
+                              </p>
+                            )}
+                            {generatorType === "barcode" && (
+                              <p className="text-sm text-slate-600">
+                                <strong>Dimensões:</strong>{" "}
+                                {
+                                  BARCODE_SIZE_OPTIONS.find(
+                                    (s) => s.value === barcodeSize
+                                  )?.dimensions
+                                }
+                              </p>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  {/* Information Tabs */}
+                  <Card className="ps-card border-brand-border-soft shadow-none">
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2 text-lg font-semibold text-brand-ink">
+                        <Info className="h-5 w-5 text-brand-ui-primary" />
+                        {t.information.title}
+                      </CardTitle>
+                      <CardDescription>
+                        {t.information.description}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <Tabs defaultValue="formats" className="w-full">
+                        <TabsList className="grid w-full grid-cols-3 bg-brand-surface-soft">
+                          <TabsTrigger value="formats">
+                            {generatorType === "barcode"
+                              ? "Formatos"
+                              : "Tipos de QR"}
+                          </TabsTrigger>
+                          <TabsTrigger value="usage">
+                            {t.information.usage.title}
+                          </TabsTrigger>
+                          <TabsTrigger value="tips">
+                            {t.information.tips.title}
+                          </TabsTrigger>
+                        </TabsList>
+
+                        <TabsContent value="formats" className="mt-6">
+                          <div className="space-y-4">
+                            {generatorType === "barcode"
+                              ? // Barcode formats
+                                BARCODE_TYPES.map((type) => (
+                                  <div
+                                    key={type.value}
+                                    className="flex items-start gap-3 rounded-lg border border-brand-border-soft p-3"
+                                  >
+                                    <div className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-brand-ui-primary"></div>
+                                    <div>
+                                      <h4 className="font-medium text-brand-ink">
+                                        {type.label}
+                                      </h4>
+                                      <p className="text-sm text-slate-600">
+                                        {type.description}
+                                      </p>
+                                      <p className="mt-1 text-xs text-slate-500">
+                                        {t.information.formats[
+                                          type.value as keyof typeof t.information.formats
+                                        ] ?? t.information.formats.default}
+                                      </p>
+                                    </div>
+                                  </div>
+                                ))
+                              : // QR Code types
+                                [
+                                  {
+                                    title: "URL",
+                                    description:
+                                      "Links para websites, redes sociais e aplicativos",
+                                  },
+                                  {
+                                    title: "Texto",
+                                    description:
+                                      "Mensagens, notas e informações estáticas",
+                                  },
+                                  {
+                                    title: "Contato (vCard)",
+                                    description:
+                                      "Informações de contato para agenda",
+                                  },
+                                  {
+                                    title: "Email",
+                                    description:
+                                      "Endereços de email com assunto e corpo",
+                                  },
+                                  {
+                                    title: "Telefone",
+                                    description:
+                                      "Números de telefone para ligação direta",
+                                  },
+                                  {
+                                    title: "SMS",
+                                    description:
+                                      "Mensagens de texto pré-formatadas",
+                                  },
+                                  {
+                                    title: "WiFi",
+                                    description: "Configurações de rede WiFi",
+                                  },
+                                  {
+                                    title: "Localização",
+                                    description: "Coordenadas GPS e endereços",
+                                  },
+                                ].map((type, index) => (
+                                  <div
+                                    key={index}
+                                    className="flex items-start gap-3 rounded-lg border border-brand-border-soft p-3"
+                                  >
+                                    <div className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-brand-ui-primary"></div>
+                                    <div>
+                                      <h4 className="font-medium text-brand-ink">
+                                        {type.title}
+                                      </h4>
+                                      <p className="text-sm text-slate-600">
+                                        {type.description}
+                                      </p>
+                                    </div>
+                                  </div>
+                                ))}
+                          </div>
+                        </TabsContent>
+
+                        <TabsContent value="usage" className="mt-6">
+                          <div className="space-y-4">
+                            <div className="grid gap-4 md:grid-cols-2">
+                              <div className="ps-proof-card p-4">
+                                <h4 className="mb-2 font-medium text-brand-ink">
+                                  {t.information.usage.retail.title}
+                                </h4>
+                                <p className="text-sm text-slate-600">
+                                  {t.information.usage.retail.description}
+                                </p>
+                              </div>
+                              <div className="rounded-lg border border-brand-border-soft bg-brand-surface-soft/80 p-4">
+                                <h4 className="mb-2 font-medium text-brand-ink">
+                                  {t.information.usage.logistics.title}
+                                </h4>
+                                <p className="text-sm text-slate-600">
+                                  {t.information.usage.logistics.description}
+                                </p>
+                              </div>
+                              <div className="rounded-lg border border-brand-border-soft bg-brand-surface-soft/80 p-4">
+                                <h4 className="mb-2 font-medium text-brand-ink">
+                                  {t.information.usage.healthcare.title}
+                                </h4>
+                                <p className="text-sm text-slate-600">
+                                  {t.information.usage.healthcare.description}
+                                </p>
+                              </div>
+                              <div className="ps-callout p-4">
+                                <h4 className="mb-2 font-medium text-brand-link-blue">
+                                  {t.information.usage.manufacturing.title}
+                                </h4>
+                                <p className="text-sm text-slate-600">
+                                  {
+                                    t.information.usage.manufacturing
+                                      .description
+                                  }
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        </TabsContent>
+
+                        <TabsContent value="tips" className="mt-6">
+                          <div className="space-y-4">
+                            {generatorType === "barcode"
+                              ? // Barcode tips
+                                t.information.tips.items.map(
+                                  (
+                                    tip: { title: string; description: string },
+                                    index: number
+                                  ) => (
+                                    <div
+                                      key={index}
+                                      className="flex items-start gap-3 rounded-lg border border-brand-border-soft p-3"
+                                    >
+                                      <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-brand-ui-primary/10 text-sm font-medium text-brand-ui-primary">
+                                        {index + 1}
+                                      </div>
+                                      <div>
+                                        <h4 className="font-medium text-brand-ink">
+                                          {tip.title}
+                                        </h4>
+                                        <p className="text-sm text-slate-600">
+                                          {tip.description}
+                                        </p>
+                                      </div>
+                                    </div>
+                                  )
+                                )
+                              : // QR Code tips
+                                [
+                                  {
+                                    title: "Escolha o tamanho correto",
+                                    description:
+                                      "Use tamanhos maiores para impressão e menores para uso digital",
+                                  },
+                                  {
+                                    title: "Configure a correção de erro",
+                                    description:
+                                      "Use correção alta (H) para impressão e baixa (L) para uso digital",
+                                  },
+                                  {
+                                    title: "Teste antes de usar",
+                                    description:
+                                      "Sempre teste o QR code com diferentes leitores antes da implementação",
+                                  },
+                                  {
+                                    title: "Mantenha contraste",
+                                    description:
+                                      "Use cores contrastantes para melhor legibilidade",
+                                  },
+                                ].map((tip, index) => (
+                                  <div
+                                    key={index}
+                                    className="flex items-start gap-3 rounded-lg border border-brand-border-soft p-3"
+                                  >
+                                    <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-brand-ui-primary/10 text-sm font-medium text-brand-ui-primary">
+                                      {index + 1}
+                                    </div>
+                                    <div>
+                                      <h4 className="font-medium text-brand-ink">
+                                        {tip.title}
+                                      </h4>
+                                      <p className="text-sm text-slate-600">
+                                        {tip.description}
+                                      </p>
+                                    </div>
+                                  </div>
+                                ))}
+                          </div>
+                        </TabsContent>
+                      </Tabs>
+                    </CardContent>
+                  </Card>
+                </div>
+              </div>
             </div>
           </div>
         </div>
+      </main>
+
+      <div className="relative z-[1]">
+        <Footer />
       </div>
-      <Footer />
-    </main>
+    </div>
   );
 }

--- a/lib/barcode-generator.ts
+++ b/lib/barcode-generator.ts
@@ -1,0 +1,261 @@
+export type BarcodeFormat =
+  | "CODE128"
+  | "CODE39"
+  | "EAN13"
+  | "EAN8"
+  | "UPC"
+  | "ITF14"
+  | "CODABAR"
+  | "ITF";
+
+export type QrPreset = "url" | "text" | "email" | "phone" | "sms" | "wifi";
+
+export type ValidationResult =
+  | { valid: true }
+  | { valid: false; error: string };
+
+export type BarcodeSizeOption = {
+  value: string;
+  label: string;
+  dimensions: string;
+};
+
+export const BARCODE_SIZE_OPTIONS: BarcodeSizeOption[] = [
+  { value: "small", label: "Pequeno", dimensions: "200x100" },
+  { value: "medium", label: "Médio", dimensions: "300x150" },
+  { value: "large", label: "Grande", dimensions: "400x200" },
+  { value: "xlarge", label: "Extra Grande", dimensions: "500x250" },
+];
+
+export type QrPresetInput = {
+  url?: string;
+  text?: string;
+  email?: string;
+  subject?: string;
+  body?: string;
+  phone?: string;
+  message?: string;
+  ssid?: string;
+  password?: string;
+  security?: "WPA" | "WEP" | "nopass";
+};
+
+const NUMERIC_FORMATS: BarcodeFormat[] = [
+  "EAN13",
+  "EAN8",
+  "UPC",
+  "ITF14",
+  "ITF",
+];
+
+function onlyDigits(value: string): string {
+  return value.replace(/\D/g, "");
+}
+
+export function sanitizeBarcodeInput(
+  format: BarcodeFormat,
+  data: string
+): string {
+  if (NUMERIC_FORMATS.includes(format)) {
+    return onlyDigits(data);
+  }
+
+  return data.trim();
+}
+
+export function validateBarcodeData(
+  format: BarcodeFormat,
+  data: string
+): ValidationResult {
+  const sanitized = sanitizeBarcodeInput(format, data);
+
+  if (!sanitized) {
+    return {
+      valid: false,
+      error: "Informe os dados do código de barras.",
+    };
+  }
+
+  if (format === "EAN13") {
+    if (!/^\d{12,13}$/.test(sanitized)) {
+      return {
+        valid: false,
+        error: "EAN-13 exige 12 ou 13 dígitos numéricos.",
+      };
+    }
+    return { valid: true };
+  }
+
+  if (format === "EAN8") {
+    if (!/^\d{7,8}$/.test(sanitized)) {
+      return {
+        valid: false,
+        error: "EAN-8 exige 7 ou 8 dígitos numéricos.",
+      };
+    }
+    return { valid: true };
+  }
+
+  if (format === "UPC") {
+    if (!/^\d{11,12}$/.test(sanitized)) {
+      return {
+        valid: false,
+        error: "UPC-A exige 11 ou 12 dígitos numéricos.",
+      };
+    }
+    return { valid: true };
+  }
+
+  if (format === "ITF" || format === "ITF14") {
+    if (!/^\d+$/.test(sanitized)) {
+      return {
+        valid: false,
+        error: "ITF exige apenas dígitos numéricos.",
+      };
+    }
+
+    if (sanitized.length % 2 !== 0) {
+      return {
+        valid: false,
+        error: "ITF exige quantidade par de dígitos numéricos.",
+      };
+    }
+
+    return { valid: true };
+  }
+
+  return { valid: true };
+}
+
+export function resolveBarcodeValue(
+  format: BarcodeFormat,
+  data: string
+): string {
+  const sanitized = sanitizeBarcodeInput(format, data);
+
+  if (format === "EAN13" && sanitized.length === 12) {
+    const checkDigit = computeEan13CheckDigit(sanitized);
+    return checkDigit ? `${sanitized}${checkDigit}` : sanitized;
+  }
+
+  return sanitized;
+}
+
+export function computeEan13CheckDigit(twelveDigits: string): string | null {
+  const digits = onlyDigits(twelveDigits);
+  if (digits.length !== 12) {
+    return null;
+  }
+
+  const sum = digits
+    .split("")
+    .map(Number)
+    .reduce((total, digit, index) => {
+      const multiplier = index % 2 === 0 ? 1 : 3;
+      return total + digit * multiplier;
+    }, 0);
+
+  const checkDigit = (10 - (sum % 10)) % 10;
+  return String(checkDigit);
+}
+
+export function normalizeUrlForQr(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `https://${trimmed}`;
+}
+
+export function buildQrPayload(preset: QrPreset, input: QrPresetInput): string {
+  switch (preset) {
+    case "url":
+      return normalizeUrlForQr(input.url ?? "");
+    case "text":
+      return (input.text ?? "").trim();
+    case "email": {
+      const email = (input.email ?? "").trim();
+      if (!email) {
+        return "";
+      }
+
+      const params = new URLSearchParams();
+      if (input.subject?.trim()) {
+        params.set("subject", input.subject.trim());
+      }
+      if (input.body?.trim()) {
+        params.set("body", input.body.trim());
+      }
+
+      const query = params.toString();
+      return query ? `mailto:${email}?${query}` : `mailto:${email}`;
+    }
+    case "phone": {
+      const phone = onlyDigits(input.phone ?? "");
+      return phone ? `tel:+${phone}` : "";
+    }
+    case "sms": {
+      const phone = onlyDigits(input.phone ?? "");
+      if (!phone) {
+        return "";
+      }
+
+      const message = (input.message ?? "").trim();
+      return message
+        ? `sms:+${phone}?body=${encodeURIComponent(message)}`
+        : `sms:+${phone}`;
+    }
+    case "wifi": {
+      const ssid = (input.ssid ?? "").trim();
+      if (!ssid) {
+        return "";
+      }
+
+      const security = input.security ?? "WPA";
+      const password = (input.password ?? "").trim();
+      return `WIFI:T:${security};S:${ssid};P:${password};;`;
+    }
+    default:
+      return "";
+  }
+}
+
+export function buildDownloadFilename(
+  generatorType: "barcode" | "qr",
+  data: string
+): string {
+  const safeData = data
+    .trim()
+    .replace(/[^a-zA-Z0-9-_]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 48);
+
+  const suffix = safeData || "codigo";
+  return `${generatorType}-${suffix}.png`;
+}
+
+export function getBarcodeCanvasDimensions(
+  sizeKey: string,
+  sizeOptions: BarcodeSizeOption[] = BARCODE_SIZE_OPTIONS
+): { width: number; height: number } {
+  const option = sizeOptions.find((size) => size.value === sizeKey);
+  if (!option) {
+    return { width: 300, height: 150 };
+  }
+
+  const [width, height] = option.dimensions.split("x").map(Number);
+  return { width, height };
+}
+
+export function getQrCanvasDimensions(
+  qrSize: number,
+  padding = 100
+): { width: number; height: number } {
+  const dimension = qrSize + padding;
+  return { width: dimension, height: dimension };
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint . --max-warnings 0",
     "audit:deps": "pnpm audit --audit-level low",
-    "test": "tsx --test tests/*.test.js tests/*.test.tsx",
+    "test": "tsx --test tests/*.test.js tests/*.test.ts tests/*.test.tsx",
     "test:ci": "npm run test",
     "prepare": "husky",
     "format": "prettier --write .",

--- a/tests/barcode-generator.test.ts
+++ b/tests/barcode-generator.test.ts
@@ -1,0 +1,145 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  BARCODE_SIZE_OPTIONS,
+  buildDownloadFilename,
+  buildQrPayload,
+  computeEan13CheckDigit,
+  resolveBarcodeValue,
+  getBarcodeCanvasDimensions,
+  getQrCanvasDimensions,
+  normalizeUrlForQr,
+  sanitizeBarcodeInput,
+  validateBarcodeData,
+  type BarcodeFormat,
+} from "../lib/barcode-generator";
+
+test("validateBarcodeData accepts non-empty CODE128 values", () => {
+  assert.deepEqual(validateBarcodeData("CODE128", "ABC-123"), { valid: true });
+});
+
+test("validateBarcodeData rejects empty barcode data", () => {
+  assert.deepEqual(validateBarcodeData("CODE128", ""), {
+    valid: false,
+    error: "Informe os dados do código de barras.",
+  });
+});
+
+test("validateBarcodeData requires 12 or 13 digits for EAN13", () => {
+  assert.deepEqual(validateBarcodeData("EAN13", "5901234123457"), {
+    valid: true,
+  });
+  assert.deepEqual(validateBarcodeData("EAN13", "590123412345"), {
+    valid: true,
+  });
+  assert.deepEqual(validateBarcodeData("EAN13", "5901234"), {
+    valid: false,
+    error: "EAN-13 exige 12 ou 13 dígitos numéricos.",
+  });
+});
+
+test("validateBarcodeData requires 7 or 8 digits for EAN8", () => {
+  assert.deepEqual(validateBarcodeData("EAN8", "9638507"), { valid: true });
+  assert.deepEqual(validateBarcodeData("EAN8", "12345"), {
+    valid: false,
+    error: "EAN-8 exige 7 ou 8 dígitos numéricos.",
+  });
+});
+
+test("validateBarcodeData requires 11 or 12 digits for UPC", () => {
+  assert.deepEqual(validateBarcodeData("UPC", "03600029145"), { valid: true });
+  assert.deepEqual(validateBarcodeData("UPC", "036000291452"), {
+    valid: true,
+  });
+  assert.deepEqual(validateBarcodeData("UPC", "123"), {
+    valid: false,
+    error: "UPC-A exige 11 ou 12 dígitos numéricos.",
+  });
+});
+
+test("validateBarcodeData requires even numeric length for ITF", () => {
+  assert.deepEqual(validateBarcodeData("ITF", "123456"), { valid: true });
+  assert.deepEqual(validateBarcodeData("ITF", "12345"), {
+    valid: false,
+    error: "ITF exige quantidade par de dígitos numéricos.",
+  });
+});
+
+test("sanitizeBarcodeInput keeps only digits for numeric formats", () => {
+  assert.equal(sanitizeBarcodeInput("EAN13", "590-1234abc"), "5901234");
+  assert.equal(sanitizeBarcodeInput("CODE128", "ABC-123"), "ABC-123");
+});
+
+test("computeEan13CheckDigit returns checksum for 12 digits", () => {
+  assert.equal(computeEan13CheckDigit("590123412345"), "7");
+});
+
+test("computeEan13CheckDigit returns null for invalid length", () => {
+  assert.equal(computeEan13CheckDigit("123"), null);
+});
+
+test("resolveBarcodeValue appends EAN13 check digit for 12 digits", () => {
+  assert.equal(resolveBarcodeValue("EAN13", "590123412345"), "5901234123457");
+});
+
+test("resolveBarcodeValue keeps 13-digit EAN13 unchanged", () => {
+  assert.equal(resolveBarcodeValue("EAN13", "5901234123457"), "5901234123457");
+});
+
+test("normalizeUrlForQr adds https when protocol is missing", () => {
+  assert.equal(
+    normalizeUrlForQr("purplestock.com.br"),
+    "https://purplestock.com.br"
+  );
+  assert.equal(
+    normalizeUrlForQr("https://purplestock.com.br"),
+    "https://purplestock.com.br"
+  );
+});
+
+test("buildQrPayload builds wifi string", () => {
+  assert.equal(
+    buildQrPayload("wifi", {
+      ssid: "Loja WiFi",
+      password: "senha123",
+      security: "WPA",
+    }),
+    "WIFI:T:WPA;S:Loja WiFi;P:senha123;;"
+  );
+});
+
+test("buildQrPayload builds mailto link", () => {
+  assert.equal(
+    buildQrPayload("email", {
+      email: "contato@empresa.com",
+      subject: "Orçamento",
+      body: "Olá",
+    }),
+    "mailto:contato@empresa.com?subject=Or%C3%A7amento&body=Ol%C3%A1"
+  );
+});
+
+test("buildQrPayload builds tel link", () => {
+  assert.equal(
+    buildQrPayload("phone", { phone: "+55 11 99999-0000" }),
+    "tel:+5511999990000"
+  );
+});
+
+test("buildDownloadFilename sanitizes unsafe characters", () => {
+  assert.equal(
+    buildDownloadFilename("barcode", "ABC/123:test"),
+    "barcode-ABC_123_test.png"
+  );
+});
+
+test("getBarcodeCanvasDimensions resolves preset size", () => {
+  assert.deepEqual(getBarcodeCanvasDimensions("medium", BARCODE_SIZE_OPTIONS), {
+    width: 300,
+    height: 150,
+  });
+});
+
+test("getQrCanvasDimensions adds padding around qr size", () => {
+  assert.deepEqual(getQrCanvasDimensions(256, 50), { width: 306, height: 306 });
+});


### PR DESCRIPTION
## Summary

Atualiza a rota `/codigo-de-barras-gratis` para seguir a linguagem visual do desktop landing e melhora a funcionalidade do gerador com lógica testável.

## Mudanças

- **Visual desktop**: canvas `ps-landing`, painel com chrome de janela, tokens de marca (`ps-panel`, `ps-card`, `ps-btn-primary`)
- **Lógica extraída**: novo módulo `lib/barcode-generator.ts` com funções puras
- **TDD**: 18 testes em `tests/barcode-generator.test.ts` (script `pnpm test` agora inclui `.test.ts`)
- **Validação por formato**: EAN-13, EAN-8, UPC, ITF com mensagens claras
- **EAN-13**: auto-completar dígito verificador e botão de sugestão
- **QR Code**: presets (URL, texto, email, telefone, SMS, WiFi) com preview do payload
- **UX**: feedback de cópia, erros de geração, download com nome sanitizado

## Test plan

- [x] `pnpm test` — 26 testes passando
- [x] `pnpm lint` — sem warnings
- [x] `pnpm format:check` — ok
- [ ] Validar manualmente `/codigo-de-barras-gratis` (barcode + QR presets + download/cópia)