### PR TITLE
fix(blog): corrigir responsivo no mobile e tablet

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -149,16 +149,16 @@ export default async function BlogPostPage({ params }: PageProps) {
   return (
     <BlogLayout showReadingProgress>
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="grid gap-10 lg:grid-cols-[1fr_340px] lg:items-start">
-          <article className="flex flex-col">
-            <div className="ps-panel overflow-hidden">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-[1fr_340px] lg:items-start">
+          <article className="flex min-w-0 w-full flex-col">
+            <div className="ps-panel w-full min-w-0 overflow-hidden">
               <div className="ps-panel-chrome flex items-center gap-2 px-4 py-2 sm:px-5">
                 <span className="text-[11px] font-medium text-slate-500">
                   Purple Stock · Editorial
                 </span>
               </div>
 
-              <div className="p-6 md:p-10">
+              <div className="p-4 sm:p-6 md:p-10">
                 <Link
                   href="/blog"
                   className="ps-link-editorial mb-8 inline-flex items-center gap-2 text-sm font-semibold"
@@ -183,10 +183,10 @@ export default async function BlogPostPage({ params }: PageProps) {
                     <span>{post.meta.author}</span>
                   </div>
 
-                  <h1 className="ps-display text-3xl md:text-4xl lg:text-5xl">
+                  <h1 className="ps-display text-2xl sm:text-3xl md:text-4xl lg:text-5xl">
                     {post.meta.title}
                   </h1>
-                  <p className="ps-lead mt-4 max-w-3xl text-lg">
+                  <p className="ps-lead mt-4 max-w-3xl text-base sm:text-lg">
                     {post.meta.excerpt}
                   </p>
                   <BlogPostCta slug={post.meta.slug} />
@@ -233,7 +233,7 @@ export default async function BlogPostPage({ params }: PageProps) {
             <BlogRelatedPosts slug={slug} />
           </article>
 
-          <div className="hidden lg:block lg:sticky lg:top-28">
+          <div className="min-w-0 lg:sticky lg:top-28 lg:self-start">
             <BlogSidebar excludeSlug={slug} />
           </div>
         </div>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -51,8 +51,8 @@ export default async function BlogPage({ searchParams }: PageProps) {
           description="Guias curtos, linguagem direta e foco em resultado para facilitar a leitura do cliente e apoiar melhorias de operação."
         />
 
-        <div className="grid gap-10 lg:grid-cols-[1fr_340px] lg:items-start">
-          <div className="flex flex-col gap-8">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-[1fr_340px] lg:items-start">
+          <div className="flex min-w-0 flex-col gap-8">
             {featured && <BlogCard post={featured} featured />}
 
             {gridPosts.length > 0 && (
@@ -106,7 +106,7 @@ export default async function BlogPage({ searchParams }: PageProps) {
             )}
           </div>
 
-          <div className="hidden lg:block lg:sticky lg:top-28">
+          <div className="min-w-0 lg:sticky lg:top-28 lg:self-start">
             <BlogSidebar />
           </div>
         </div>

--- a/app/blog/tag/[tag]/page.tsx
+++ b/app/blog/tag/[tag]/page.tsx
@@ -81,14 +81,14 @@ export default async function BlogTagPage({ params }: PageProps) {
           }
         />
 
-        <div className="grid gap-10 lg:grid-cols-[1fr_340px] lg:items-start">
-          <div className="grid gap-6 sm:grid-cols-2">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-[1fr_340px] lg:items-start">
+          <div className="grid min-w-0 gap-6 sm:grid-cols-2">
             {posts.map((post) => (
               <BlogCard key={post.slug} post={post} />
             ))}
           </div>
 
-          <div className="hidden lg:block lg:sticky lg:top-28">
+          <div className="min-w-0 lg:sticky lg:top-28 lg:self-start">
             <BlogSidebar />
           </div>
         </div>

--- a/components/blog-card.tsx
+++ b/components/blog-card.tsx
@@ -23,11 +23,11 @@ export function BlogCard({
 
   if (featured) {
     return (
-      <article className="ps-card group overflow-hidden transition-transform duration-300 hover:-translate-y-0.5">
-        <div className="grid gap-0 md:grid-cols-[1.1fr_1fr]">
+      <article className="ps-card group min-w-0 overflow-hidden transition-transform duration-300 hover:-translate-y-0.5">
+        <div className="grid min-w-0 gap-0 lg:grid-cols-[1.1fr_1fr]">
           <Link
             href={`/blog/${post.slug}`}
-            className="relative block min-h-64 overflow-hidden md:min-h-full"
+            className="relative block min-h-48 overflow-hidden sm:min-h-56 lg:min-h-full"
           >
             <Image
               src={cover}
@@ -38,7 +38,7 @@ export function BlogCard({
             />
           </Link>
 
-          <div className="flex flex-col justify-center p-6 md:p-10">
+          <div className="flex min-w-0 flex-col justify-center p-4 sm:p-6 lg:p-10">
             <div className="mb-3 flex flex-wrap items-center gap-3 text-sm text-slate-500">
               <span className="ps-badge-violet px-2.5 py-0.5 normal-case tracking-normal">
                 Em destaque
@@ -52,7 +52,7 @@ export function BlogCard({
               </span>
             </div>
 
-            <h2 className="ps-display text-2xl md:text-3xl lg:text-4xl">
+            <h2 className="ps-display text-xl sm:text-2xl lg:text-3xl xl:text-4xl">
               <Link
                 href={`/blog/${post.slug}`}
                 className="transition-colors hover:text-brand-ui-primary"
@@ -93,7 +93,7 @@ export function BlogCard({
   }
 
   return (
-    <article className="ps-card group flex flex-col overflow-hidden transition-transform duration-300 hover:-translate-y-0.5">
+    <article className="ps-card group flex min-w-0 flex-col overflow-hidden transition-transform duration-300 hover:-translate-y-0.5">
       <Link
         href={`/blog/${post.slug}`}
         className="relative block aspect-[16/10] overflow-hidden"

--- a/components/blog-layout.tsx
+++ b/components/blog-layout.tsx
@@ -21,7 +21,9 @@ export function BlogLayout({
       {showReadingProgress && <BlogReadingProgress />}
       <Navbar />
 
-      <main className="relative z-[1] pt-24 pb-20">{children}</main>
+      <main className="relative z-[1] pt-14 pb-16 sm:pt-20 sm:pb-20">
+        {children}
+      </main>
 
       <div className="relative z-[1]">
         <Footer />

--- a/components/blog-page-header.tsx
+++ b/components/blog-page-header.tsx
@@ -14,14 +14,16 @@ export function BlogPageHeader({
   before,
 }: BlogPageHeaderProps) {
   return (
-    <header className="ps-panel mx-auto mb-12 max-w-5xl p-8 text-center md:p-12">
-      {before ? <div className="mb-6">{before}</div> : null}
-      <div className="ps-badge-violet mb-6 inline-flex items-center gap-2 px-4 py-2 text-sm normal-case tracking-normal">
+    <header className="ps-panel mx-auto mb-8 max-w-5xl p-5 text-center sm:mb-12 sm:p-8 md:p-12">
+      {before ? <div className="mb-4 sm:mb-6">{before}</div> : null}
+      <div className="ps-badge-violet mb-4 inline-flex items-center gap-2 px-4 py-2 text-sm normal-case tracking-normal sm:mb-6">
         {badge}
       </div>
-      <h1 className="ps-display text-4xl md:text-5xl lg:text-6xl">{title}</h1>
+      <h1 className="ps-display text-3xl sm:text-4xl md:text-5xl lg:text-6xl">
+        {title}
+      </h1>
       {description ? (
-        <p className="ps-lead mx-auto mt-6 max-w-3xl text-lg md:text-xl">
+        <p className="ps-lead mx-auto mt-4 max-w-3xl text-base sm:mt-6 sm:text-lg md:text-xl">
           {description}
         </p>
       ) : null}

--- a/components/blog-post-cta.tsx
+++ b/components/blog-post-cta.tsx
@@ -76,9 +76,10 @@ export function BlogPostCta({ slug }: BlogPostCtaProps) {
   };
 
   return (
-    <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+    <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
       <Link
         href="https://app.purplestock.com.br/"
+        className="w-full sm:w-auto"
         onClick={() =>
           trackSeoCtaClick({
             cta_name: "blog_post_primary_trial",
@@ -88,13 +89,14 @@ export function BlogPostCta({ slug }: BlogPostCtaProps) {
           })
         }
       >
-        <Button className="ps-btn-primary">
+        <Button className="ps-btn-primary w-full sm:w-auto">
           {cta.primaryLabel}
           <ArrowRight className="ml-2 h-4 w-4" />
         </Button>
       </Link>
       <Link
         href={buildWhatsAppUrl(decodeURIComponent(cta.whatsappText))}
+        className="w-full sm:w-auto"
         onClick={() =>
           trackSeoCtaClick({
             cta_name: "blog_post_secondary_whatsapp",
@@ -104,7 +106,7 @@ export function BlogPostCta({ slug }: BlogPostCtaProps) {
           })
         }
       >
-        <Button variant="outline" className="ps-btn-outline">
+        <Button variant="outline" className="ps-btn-outline w-full sm:w-auto">
           <MessageCircle className="mr-2 h-4 w-4" />
           {cta.secondaryLabel}
         </Button>

--- a/components/blog-related-posts.tsx
+++ b/components/blog-related-posts.tsx
@@ -17,20 +17,20 @@ export async function BlogRelatedPosts({ slug }: { slug: string }) {
   if (posts.length === 0) return null;
 
   return (
-    <section className="mt-12">
-      <div className="ps-section-surface p-6 sm:p-8">
-        <h2 className="ps-display flex items-center gap-2 text-2xl">
+    <section className="mt-8 min-w-0 sm:mt-12">
+      <div className="ps-section-surface min-w-0 p-4 sm:p-6 md:p-8">
+        <h2 className="ps-display flex items-center gap-2 text-xl sm:text-2xl">
           <span className="inline-block h-6 w-1 rounded-full bg-brand-ui-primary" />
           Leia também
         </h2>
 
-        <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-6 grid min-w-0 gap-4 sm:mt-8 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
           {posts.map((post) => {
             const cover = post.coverImage ?? "/images/hero-photo-900x600.webp";
             return (
               <article
                 key={post.slug}
-                className="ps-card group flex flex-col overflow-hidden transition-transform duration-300 hover:-translate-y-0.5"
+                className="ps-card group flex min-w-0 flex-col overflow-hidden transition-transform duration-300 hover:-translate-y-0.5"
               >
                 <Link
                   href={`/blog/${post.slug}`}

--- a/components/blog-sidebar.tsx
+++ b/components/blog-sidebar.tsx
@@ -24,8 +24,8 @@ export async function BlogSidebar({ excludeSlug }: { excludeSlug?: string }) {
   const latest = filtered.slice(0, 4);
 
   return (
-    <aside className="flex flex-col gap-8">
-      <div className="ps-panel border-2 border-brand-ui-primary/20 p-6">
+    <aside className="flex min-w-0 flex-col gap-6 sm:gap-8">
+      <div className="ps-panel border-2 border-brand-ui-primary/20 p-4 sm:p-6">
         <h3 className="ps-display text-lg">Quer testar na prática?</h3>
         <p className="ps-lead mt-2 text-sm">
           Cadastre-se gratuitamente e comece a controlar seu estoque com QR Code
@@ -41,7 +41,7 @@ export async function BlogSidebar({ excludeSlug }: { excludeSlug?: string }) {
         </div>
       </div>
 
-      <div className="ps-card p-6">
+      <div className="ps-card p-4 sm:p-6">
         <h3 className="flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-slate-900">
           <TrendingUp className="h-4 w-4 text-brand-ui-primary" />
           Recentes
@@ -78,7 +78,7 @@ export async function BlogSidebar({ excludeSlug }: { excludeSlug?: string }) {
       </div>
 
       {popularTags.length > 0 && (
-        <div className="ps-card p-6">
+        <div className="ps-card p-4 sm:p-6">
           <h3 className="flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-slate-900">
             <Hash className="h-4 w-4 text-brand-ui-primary" />
             Tags populares

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,25 +1,108 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronDown, Globe, Box, ArrowRight } from "lucide-react";
+import { ChevronDown, Globe, Box, ArrowRight, Menu } from "lucide-react";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { translations } from "@/utils/translations";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { trackSeoCtaClick } from "@/lib/analytics";
+
+const PRIMARY_FEATURE_LINKS = [
+  {
+    href: "/features/inventory-control",
+    key: "inventoryControl" as const,
+    shortcut: "⌘I",
+  },
+  {
+    href: "/features/barcoding",
+    key: "barcoding" as const,
+    shortcut: "⌘B",
+  },
+  {
+    href: "/features/purchase-sales",
+    key: "purchaseSales" as const,
+    shortcut: "⌘P",
+  },
+  {
+    href: "/features/analytics-reporting",
+    key: "analyticsReporting" as const,
+    shortcut: "⌘R",
+  },
+  {
+    href: "/features/warehouse-control",
+    key: "warehouseControl" as const,
+    shortcut: "⌘W",
+  },
+  {
+    href: "/features/qr-code-management",
+    key: "qrCodeManagement" as const,
+    shortcut: "⌘Q",
+  },
+] as const;
+
+const SECONDARY_FEATURE_LINKS = [
+  {
+    href: "/features/clothing-manufacturing",
+    key: "clothingManufacturing" as const,
+  },
+  {
+    href: "/features/equipment-management",
+    key: "equipmentManagement" as const,
+  },
+  {
+    href: "/features/factory-management",
+    key: "factoryManagement" as const,
+  },
+  {
+    href: "/features/inventory-app",
+    key: "inventoryApp" as const,
+  },
+] as const;
 
 export function Navbar() {
   const { language, setLanguage } = useLanguage();
   const t = translations[language].nav;
   const [featuresOpen, setFeaturesOpen] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [mobileFeaturesOpen, setMobileFeaturesOpen] = useState(false);
   const [currentTime, setCurrentTime] = useState<string | null>(null);
   const featuresRef = useRef<HTMLDivElement>(null);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
+  const documentationLabel =
+    language === "pt"
+      ? "Documentação"
+      : language === "en"
+        ? "Documentation"
+        : "Documentation";
   const navLabel =
     language === "pt"
       ? "Navegação principal"
       : language === "fr"
         ? "Navigation principale"
         : "Primary navigation";
+  const mobileMenuLabel =
+    language === "pt"
+      ? "Abrir menu de navegação"
+      : language === "fr"
+        ? "Ouvrir le menu de navigation"
+        : "Open navigation menu";
+  const primaryFeatureLinks = useMemo(
+    () =>
+      PRIMARY_FEATURE_LINKS.map((item) => ({
+        ...item,
+        label: t.features[item.key],
+      })),
+    [t.features]
+  );
+  const secondaryFeatureLinks = useMemo(
+    () =>
+      SECONDARY_FEATURE_LINKS.map((item) => ({
+        ...item,
+        label: t.features[item.key],
+      })),
+    [t.features]
+  );
 
   useEffect(() => {
     const updateTime = () => {
@@ -47,11 +130,24 @@ export function Navbar() {
       ) {
         setFeaturesOpen(false);
       }
+
+      if (
+        mobileMenuRef.current &&
+        !mobileMenuRef.current.contains(event.target as Node)
+      ) {
+        setMobileMenuOpen(false);
+        setMobileFeaturesOpen(false);
+      }
     }
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
+
+  const closeMobileMenu = () => {
+    setMobileMenuOpen(false);
+    setMobileFeaturesOpen(false);
+  };
 
   return (
     <header className="fixed top-0 left-0 right-0 z-[120] h-[25px] bg-gradient-to-b from-brand-chrome-steel to-brand-chrome-graphite shadow-[0_1px_0_rgba(255,255,255,0.05),inset_0_1px_0_rgba(255,255,255,0.1)]">
@@ -75,6 +171,106 @@ export function Navbar() {
             Purple Stock
           </span>
 
+          <div className="relative md:hidden" ref={mobileMenuRef}>
+            <button
+              type="button"
+              className={cn(
+                "flex items-center justify-center w-8 h-full transition-colors",
+                mobileMenuOpen ? "bg-[#0058d0] text-white" : "hover:bg-white/10"
+              )}
+              onClick={() => setMobileMenuOpen((open) => !open)}
+              aria-expanded={mobileMenuOpen}
+              aria-haspopup="menu"
+              aria-label={mobileMenuLabel}
+            >
+              <Menu className="w-[14px] h-[14px]" strokeWidth={2.5} />
+            </button>
+
+            {mobileMenuOpen && (
+              <div className="absolute left-0 top-full mt-[3px] w-[min(100vw-1.5rem,18rem)] max-h-[calc(100vh-2rem)] overflow-y-auto rounded-md border border-white/10 bg-brand-chrome-graphite/95 py-1 shadow-[0_10px_40px_rgba(10,10,10,0.32)] backdrop-blur-xl animate-in fade-in slide-in-from-top-1 duration-150">
+                <button
+                  type="button"
+                  className={cn(
+                    "flex w-full items-center justify-between px-3 py-2 text-[13px] text-white/90 transition-colors mx-1 rounded-[3px]",
+                    mobileFeaturesOpen
+                      ? "bg-[#0058d0] text-white"
+                      : "hover:bg-[#0058d0] hover:text-white"
+                  )}
+                  onClick={() => setMobileFeaturesOpen((open) => !open)}
+                  aria-expanded={mobileFeaturesOpen}
+                >
+                  <span>{t.resources}</span>
+                  <ChevronDown
+                    className={cn(
+                      "w-3.5 h-3.5 text-white/50 transition-transform",
+                      mobileFeaturesOpen && "rotate-180"
+                    )}
+                  />
+                </button>
+
+                {mobileFeaturesOpen && (
+                  <div className="pb-1">
+                    {primaryFeatureLinks.map((item) => (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        className="flex items-center justify-between px-4 py-1.5 text-[13px] text-white/80 hover:bg-[#0058d0] hover:text-white transition-colors mx-1 rounded-[3px]"
+                        onClick={closeMobileMenu}
+                      >
+                        <span>{item.label}</span>
+                        <span className="text-[11px] text-white/40">
+                          {item.shortcut}
+                        </span>
+                      </Link>
+                    ))}
+                    <div className="h-px bg-white/10 my-1 mx-3" />
+                    {secondaryFeatureLinks.map((item) => (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        className="flex items-center px-4 py-1.5 text-[13px] text-white/80 hover:bg-[#0058d0] hover:text-white transition-colors mx-1 rounded-[3px]"
+                        onClick={closeMobileMenu}
+                      >
+                        {item.label}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+
+                <div className="h-px bg-white/10 my-1 mx-3" />
+
+                <Link
+                  href="/industrias"
+                  className="flex items-center px-3 py-2 text-[13px] text-white/90 hover:bg-[#0058d0] hover:text-white transition-colors mx-1 rounded-[3px]"
+                  onClick={closeMobileMenu}
+                >
+                  {t.industries}
+                </Link>
+                <Link
+                  href="/blog"
+                  className="flex items-center px-3 py-2 text-[13px] text-white/90 hover:bg-[#0058d0] hover:text-white transition-colors mx-1 rounded-[3px]"
+                  onClick={closeMobileMenu}
+                >
+                  {t.blog}
+                </Link>
+                <Link
+                  href="/documentacao"
+                  className="flex items-center px-3 py-2 text-[13px] text-white/90 hover:bg-[#0058d0] hover:text-white transition-colors mx-1 rounded-[3px]"
+                  onClick={closeMobileMenu}
+                >
+                  {documentationLabel}
+                </Link>
+                <Link
+                  href="/codigo-de-barras-gratis"
+                  className="flex items-center px-3 py-2 text-[13px] text-violet-300 hover:bg-[#0058d0] hover:text-white transition-colors mx-1 rounded-[3px]"
+                  onClick={closeMobileMenu}
+                >
+                  {t.freeBarcode}
+                </Link>
+              </div>
+            )}
+          </div>
+
           <nav aria-label={navLabel} className="hidden md:flex items-center">
             <div className="relative" ref={featuresRef}>
               <button
@@ -92,38 +288,7 @@ export function Navbar() {
 
               {featuresOpen && (
                 <div className="absolute left-0 mt-[3px] w-64 rounded-md border border-white/10 bg-brand-chrome-graphite/95 py-1 shadow-[0_10px_40px_rgba(10,10,10,0.32)] backdrop-blur-xl animate-in fade-in slide-in-from-top-1 duration-150 overflow-hidden">
-                  {[
-                    {
-                      href: "/features/inventory-control",
-                      label: t.features.inventoryControl,
-                      shortcut: "⌘I",
-                    },
-                    {
-                      href: "/features/barcoding",
-                      label: t.features.barcoding,
-                      shortcut: "⌘B",
-                    },
-                    {
-                      href: "/features/purchase-sales",
-                      label: t.features.purchaseSales,
-                      shortcut: "⌘P",
-                    },
-                    {
-                      href: "/features/analytics-reporting",
-                      label: t.features.analyticsReporting,
-                      shortcut: "⌘R",
-                    },
-                    {
-                      href: "/features/warehouse-control",
-                      label: t.features.warehouseControl,
-                      shortcut: "⌘W",
-                    },
-                    {
-                      href: "/features/qr-code-management",
-                      label: t.features.qrCodeManagement,
-                      shortcut: "⌘Q",
-                    },
-                  ].map((item) => (
+                  {primaryFeatureLinks.map((item) => (
                     <Link
                       key={item.href}
                       href={item.href}
@@ -137,24 +302,7 @@ export function Navbar() {
                     </Link>
                   ))}
                   <div className="h-px bg-white/10 my-1 mx-3" />
-                  {[
-                    {
-                      href: "/features/clothing-manufacturing",
-                      label: t.features.clothingManufacturing,
-                    },
-                    {
-                      href: "/features/equipment-management",
-                      label: t.features.equipmentManagement,
-                    },
-                    {
-                      href: "/features/factory-management",
-                      label: t.features.factoryManagement,
-                    },
-                    {
-                      href: "/features/inventory-app",
-                      label: t.features.inventoryApp,
-                    },
-                  ].map((item) => (
+                  {secondaryFeatureLinks.map((item) => (
                     <Link
                       key={item.href}
                       href={item.href}
@@ -184,11 +332,7 @@ export function Navbar() {
               href="/documentacao"
               className="px-3 py-0.5 hover:bg-white/10 rounded-[3px] transition-colors"
             >
-              {language === "pt"
-                ? "Documentação"
-                : language === "en"
-                  ? "Documentation"
-                  : "Documentation"}
+              {documentationLabel}
             </Link>
             <Link
               href="/codigo-de-barras-gratis"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -309,6 +309,9 @@ h6 {
   font-family: "Merriweather", Georgia, serif;
   font-size: 1.12rem;
   line-height: 1.86;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .blog-content > * {
@@ -517,34 +520,71 @@ h6 {
 
 @media (max-width: 768px) {
   .blog-content {
-    font-size: 1.03rem;
+    font-size: 1rem;
     line-height: 1.78;
   }
 
+  .blog-content > * {
+    max-width: 100%;
+  }
+
   .blog-content h2 {
-    margin-top: 2.7rem;
-    margin-bottom: 1rem;
-    font-size: 1.85rem;
+    margin-top: 2.2rem;
+    margin-bottom: 0.9rem;
+    font-size: 1.45rem;
   }
 
   .blog-content h3 {
-    margin-top: 2rem;
-    margin-bottom: 0.8rem;
-    font-size: 1.42rem;
+    margin-top: 1.8rem;
+    margin-bottom: 0.75rem;
+    font-size: 1.25rem;
+  }
+
+  .blog-content h4 {
+    margin-top: 1.4rem;
+    margin-bottom: 0.6rem;
+    font-size: 1.1rem;
   }
 
   .blog-content ul,
   .blog-content ol {
     margin: 1rem 0 1.4rem;
-    padding-left: 1.35rem;
+    padding-left: 1.25rem;
   }
 
   .blog-content pre {
-    padding: 1rem;
-    font-size: 0.82rem;
+    padding: 0.9rem;
+    font-size: 0.8rem;
+    max-width: 100%;
   }
 
   .blog-content blockquote {
-    padding: 1.2rem 1.2rem;
+    padding: 1rem;
+    margin: 1.6rem 0;
+  }
+
+  .blog-content table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    font-size: 0.88rem;
+  }
+
+  .blog-content thead,
+  .blog-content tbody {
+    display: table;
+    width: 100%;
+  }
+
+  .blog-content th,
+  .blog-content td {
+    padding: 0.6rem 0.7rem;
+    white-space: nowrap;
+  }
+
+  .blog-content img {
+    margin: 1.4rem auto;
+    border-radius: 10px;
   }
 }


### PR DESCRIPTION
## Summary

- Corrige overflow horizontal no blog mobile causado por `min-width: auto` nos filhos do CSS Grid
- Ajusta tipografia, padding e CTAs para telas pequenas
- Exibe a sidebar abaixo do conteúdo em mobile/tablet (antes ficava escondida)
- Adiciona scroll horizontal para tabelas no conteúdo editorial em telas menores
- Card em destaque passa a empilhar até `lg` (1024px), evitando layout apertado em tablet

## Problema

No artigo do blog, o grid tinha ~358px de largura útil, mas o `<article>` interno estourava para ~464px. O conteúdo era cortado pela lateral direita por causa do `overflow-x-hidden` do layout.

## Test plan

- [x] Verificado no mobile (390px): sem overflow horizontal
- [x] `pnpm test` passou
- [x] `pnpm lint` e `format:check` passaram
- [ ] Revisar `/blog` em mobile e tablet
- [ ] Revisar artigo individual em mobile
- [ ] Confirmar sidebar visível abaixo do conteúdo em telas < lg