### PR TITLE
feat: centralizar links do app com variável de ambiente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_BASE_URL=https://www.purplestock.com.br
+NEXT_PUBLIC_APP_URL=https://app.gestaobem.com
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 NEXT_PUBLIC_WHATSAPP_URL=https://wa.me/5511995597242
 NEXT_PUBLIC_CALENDLY_URL=https://calendly.com/matheus-puppe/purple-stock

--- a/app/features/analytics-reporting/page.tsx
+++ b/app/features/analytics-reporting/page.tsx
@@ -19,6 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { translations } from "@/utils/translations";
 
 export default function AnalyticsReportingPage() {
@@ -56,7 +57,7 @@ export default function AnalyticsReportingPage() {
 
               <div className="flex flex-col sm:flex-row gap-4">
                 {/* <Link href="/coming-soon"> */}
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button
                     size="lg"
                     className="bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -304,7 +305,7 @@ export default function AnalyticsReportingPage() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-transparent border-2 border-white hover:bg-white/10 text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1"

--- a/app/features/barcoding/page.tsx
+++ b/app/features/barcoding/page.tsx
@@ -19,6 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { translations } from "@/utils/translations";
 
 export default function BarcodingPage() {
@@ -56,7 +57,7 @@ export default function BarcodingPage() {
 
               <div className="flex flex-col sm:flex-row gap-4">
                 {/* <Link href="/coming-soon"> */}
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button
                     size="lg"
                     className="bg-gradient-to-r from-teal-600 to-teal-700 hover:from-teal-700 hover:to-teal-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -307,7 +308,7 @@ export default function BarcodingPage() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-transparent border-2 border-white hover:bg-white/10 text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1"

--- a/app/features/clothing-manufacturing/page.tsx
+++ b/app/features/clothing-manufacturing/page.tsx
@@ -19,6 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { translations } from "@/utils/translations";
 
 export default function ClothingManufacturingPage() {
@@ -56,7 +57,7 @@ export default function ClothingManufacturingPage() {
 
               <div className="flex flex-col sm:flex-row gap-4">
                 {/* <Link href="/coming-soon"> */}
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button
                     size="lg"
                     className="bg-gradient-to-r from-pink-600 to-pink-700 hover:from-pink-700 hover:to-pink-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -369,7 +370,7 @@ export default function ClothingManufacturingPage() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-transparent border-2 border-white hover:bg-white/10 text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1"

--- a/app/features/equipment-management/page.tsx
+++ b/app/features/equipment-management/page.tsx
@@ -19,6 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { translations } from "@/utils/translations";
 
 export default function EquipmentManagementPage() {
@@ -56,7 +57,7 @@ export default function EquipmentManagementPage() {
 
               <div className="flex flex-col sm:flex-row gap-4">
                 {/* <Link href="/coming-soon"> */}
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button
                     size="lg"
                     className="bg-gradient-to-r from-slate-600 to-slate-700 hover:from-slate-700 hover:to-slate-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -303,7 +304,7 @@ export default function EquipmentManagementPage() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-transparent border-2 border-white hover:bg-white/10 text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1"

--- a/app/features/factory-management/page.tsx
+++ b/app/features/factory-management/page.tsx
@@ -19,6 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { translations } from "@/utils/translations";
 
 export default function FactoryManagementPage() {
@@ -56,7 +57,7 @@ export default function FactoryManagementPage() {
 
               <div className="flex flex-col sm:flex-row gap-4">
                 {/* <Link href="/coming-soon"> */}
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button
                     size="lg"
                     className="bg-gradient-to-r from-emerald-600 to-emerald-700 hover:from-emerald-700 hover:to-emerald-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -302,7 +303,7 @@ export default function FactoryManagementPage() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-transparent border-2 border-white hover:bg-white/10 text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1"

--- a/app/features/inventory-app/page.tsx
+++ b/app/features/inventory-app/page.tsx
@@ -19,6 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { translations } from "@/utils/translations";
 
 export default function InventoryAppPage() {
@@ -56,7 +57,7 @@ export default function InventoryAppPage() {
 
               <div className="flex flex-col sm:flex-row gap-4">
                 {/* <Link href="/coming-soon"> */}
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button
                     size="lg"
                     className="bg-gradient-to-r from-violet-600 to-violet-700 hover:from-violet-700 hover:to-violet-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -301,7 +302,7 @@ export default function InventoryAppPage() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-transparent border-2 border-white hover:bg-white/10 text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1"

--- a/app/features/inventory-control/page.tsx
+++ b/app/features/inventory-control/page.tsx
@@ -19,6 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { translations } from "@/utils/translations";
 
 export default function InventoryControlPage() {
@@ -56,7 +57,7 @@ export default function InventoryControlPage() {
 
               <div className="flex flex-col sm:flex-row gap-4">
                 {/* <Link href="/coming-soon"> */}
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button
                     size="lg"
                     className="bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -301,7 +302,7 @@ export default function InventoryControlPage() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-transparent border-2 border-white hover:bg-white/10 text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1"

--- a/app/features/purchase-sales/page.tsx
+++ b/app/features/purchase-sales/page.tsx
@@ -19,6 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { translations } from "@/utils/translations";
 
 export default function PurchaseSalesPage() {
@@ -56,7 +57,7 @@ export default function PurchaseSalesPage() {
 
               <div className="flex flex-col sm:flex-row gap-4">
                 {/* <Link href="/coming-soon"> */}
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button
                     size="lg"
                     className="bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -307,7 +308,7 @@ export default function PurchaseSalesPage() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-transparent border-2 border-white hover:bg-white/10 text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1"

--- a/app/features/qr-code-management/page.tsx
+++ b/app/features/qr-code-management/page.tsx
@@ -19,6 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { translations } from "@/utils/translations";
 
 export default function QRCodeManagementPage() {
@@ -56,7 +57,7 @@ export default function QRCodeManagementPage() {
 
               <div className="flex flex-col sm:flex-row gap-4">
                 {/* <Link href="/coming-soon"> */}
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button
                     size="lg"
                     className="bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -306,7 +307,7 @@ export default function QRCodeManagementPage() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-transparent border-2 border-white hover:bg-white/10 text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1"

--- a/app/features/warehouse-control/page.tsx
+++ b/app/features/warehouse-control/page.tsx
@@ -19,6 +19,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { translations } from "@/utils/translations";
 
 export default function WarehouseControlPage() {
@@ -56,7 +57,7 @@ export default function WarehouseControlPage() {
 
               <div className="flex flex-col sm:flex-row gap-4">
                 {/* <Link href="/coming-soon"> */}
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button
                     size="lg"
                     className="bg-gradient-to-r from-orange-600 to-orange-700 hover:from-orange-700 hover:to-orange-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -305,7 +306,7 @@ export default function WarehouseControlPage() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-transparent border-2 border-white hover:bg-white/10 text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1"

--- a/app/glossario/[slug]/page.tsx
+++ b/app/glossario/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
 import { glossaryTerms, type GlossaryTerm } from "@/data/glossary";
 import { getSiteUrl } from "@/lib/site";
 import { buildWhatsAppUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
@@ -428,7 +429,7 @@ export default async function GlossaryTermPage({ params }: PageProps) {
                 total, relatórios inteligentes e alertas automáticos.
               </p>
               <div className="flex flex-col sm:flex-row gap-3 justify-center">
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button className="bg-purple-700 text-white hover:bg-purple-800">
                     Testar Purple Stock grátis
                     <ArrowRight className="ml-2 h-4 w-4" />

--- a/app/industrias/page.tsx
+++ b/app/industrias/page.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { trackSeoCtaClick } from "@/lib/analytics";
+import { getAppSignupUrl } from "@/lib/app";
 
 type IndustryId =
   | "varejo"
@@ -398,7 +399,7 @@ export default function IndustriasPage() {
 
                 <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
                   <Link
-                    href="https://app.purplestock.com.br/"
+                    href={getAppSignupUrl()}
                     onClick={() =>
                       trackSeoCtaClick({
                         cta_name: "industries_hero_primary",
@@ -649,7 +650,7 @@ export default function IndustriasPage() {
             </p>
 
             <div className="mt-8 flex flex-col justify-center gap-4 sm:flex-row">
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="ps-btn-primary px-8 py-4 text-lg shadow-[0_8px_28px_rgba(139,92,246,0.4)]"

--- a/app/precos/page.tsx
+++ b/app/precos/page.tsx
@@ -16,6 +16,7 @@ import { Footer } from "@/components/footer";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { trackSeoCtaClick } from "@/lib/analytics";
 import { buildWhatsAppUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 
 const MONTHLY_PRICE = 59;
 
@@ -433,7 +434,7 @@ export default function PricingPage() {
 
                 <div className="mt-8 flex flex-col gap-4 sm:flex-row">
                   <Link
-                    href="https://app.purplestock.com.br/"
+                    href={getAppSignupUrl()}
                     className="flex-1"
                     onClick={() =>
                       trackSeoCtaClick({
@@ -570,7 +571,7 @@ export default function PricingPage() {
             </p>
             <div className="mt-8 flex flex-col justify-center gap-4 sm:flex-row">
               <Link
-                href="https://app.purplestock.com.br/"
+                href={getAppSignupUrl()}
                 onClick={() =>
                   trackSeoCtaClick({
                     cta_name: "pricing_single_bottom_primary",

--- a/app/recursos/controle-de-almoxarifado/page.tsx
+++ b/app/recursos/controle-de-almoxarifado/page.tsx
@@ -6,6 +6,7 @@ import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { trackSeoCtaClick } from "@/lib/analytics";
+import { buildAppUrl } from "@/lib/app";
 import { buildWhatsAppUrl } from "@/lib/contact";
 
 const checklist = [
@@ -48,7 +49,11 @@ export default function ControleAlmoxarifadoPage() {
           </p>
           <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Link
-              href="https://app.purplestock.com.br/?utm_source=site&utm_medium=organic&utm_campaign=controle_almoxarifado"
+              href={buildAppUrl("sign_up", {
+                utm_source: "site",
+                utm_medium: "organic",
+                utm_campaign: "controle_almoxarifado",
+              })}
               onClick={() =>
                 trackSeoCtaClick({
                   cta_name: "almoxarifado_hero_primary",

--- a/components/blog-post-cta.tsx
+++ b/components/blog-post-cta.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, MessageCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { trackSeoCtaClick } from "@/lib/analytics";
 import { buildWhatsAppUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 
 type BlogPostCtaProps = {
   slug: string;
@@ -78,7 +79,7 @@ export function BlogPostCta({ slug }: BlogPostCtaProps) {
   return (
     <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
       <Link
-        href="https://app.purplestock.com.br/"
+        href={getAppSignupUrl()}
         className="w-full sm:w-auto"
         onClick={() =>
           trackSeoCtaClick({

--- a/components/blog-sidebar.tsx
+++ b/components/blog-sidebar.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { getAppSignupUrl } from "@/lib/app";
 import Image from "next/image";
 import { ArrowRight, Hash, TrendingUp } from "lucide-react";
 import { getAllPosts, getPopularTags } from "@/lib/blog";
@@ -32,7 +33,7 @@ export async function BlogSidebar({ excludeSlug }: { excludeSlug?: string }) {
           em minutos.
         </p>
         <div className="mt-4">
-          <Link href="https://app.purplestock.com.br/" target="_blank">
+          <Link href={getAppSignupUrl()} target="_blank">
             <Button className="ps-btn-primary w-full">
               Criar conta grátis
               <ArrowRight className="ml-2 h-4 w-4" />

--- a/components/desktop-landing.tsx
+++ b/components/desktop-landing.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { useLanguage } from "@/contexts/LanguageContext";
 
+import { getAppSignupUrl } from "@/lib/app";
 import { trackCtaClick, trackSeoLandingView } from "@/lib/analytics";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
@@ -76,11 +77,7 @@ export function DesktopLanding() {
 
   const openApp = useCallback(() => {
     if (typeof window === "undefined") return;
-    window.open(
-      "https://app.purplestock.com.br/",
-      "_blank",
-      "noopener,noreferrer"
-    );
+    window.open(getAppSignupUrl(), "_blank", "noopener,noreferrer");
   }, []);
 
   const scrollLandingToTop = useCallback(() => {
@@ -778,7 +775,7 @@ export function DesktopLanding() {
                     className="ps-btn-primary px-8 py-6 text-base"
                   >
                     <Link
-                      href="https://app.purplestock.com.br/"
+                      href={getAppSignupUrl()}
                       onClick={() =>
                         trackCtaClick({
                           cta_name: "desktop_trial_primary",
@@ -1065,7 +1062,7 @@ export function DesktopLanding() {
                   className="ps-btn-primary px-8 py-6 text-base"
                 >
                   <Link
-                    href="https://app.purplestock.com.br/"
+                    href={getAppSignupUrl()}
                     onClick={() =>
                       trackCtaClick({
                         cta_name: "desktop_trial_secondary",

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -14,6 +14,7 @@ import { useLanguage } from "@/contexts/LanguageContext";
 import { translations } from "@/utils/translations";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { getAppSignupUrl } from "@/lib/app";
 
 interface FeatureProps {
   title: string;
@@ -83,7 +84,7 @@ function Feature({
             {/* CTA Button */}
             <div className="pt-4">
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className={`bg-gradient-to-r ${gradient} hover:shadow-xl text-white px-8 py-4 text-lg font-semibold transition-all duration-300 transform hover:-translate-y-1 rounded-xl`}

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -6,6 +6,7 @@ import { useLanguage } from "@/contexts/LanguageContext";
 import { translations } from "@/utils/translations";
 import Image from "next/image";
 import Link from "next/link";
+import { getAppSignupUrl } from "@/lib/app";
 
 export function Hero() {
   const { language } = useLanguage();
@@ -91,7 +92,7 @@ export function Hero() {
             {/* CTA Buttons */}
             <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
@@ -102,7 +103,7 @@ export function Hero() {
                 </Button>
               </Link>
               {/* <Link href="/coming-soon"> */}
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   variant="outline"
                   size="lg"

--- a/components/industry-detail-view.tsx
+++ b/components/industry-detail-view.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getCalendlyUrl } from "@/lib/contact";
+import { getAppSignupUrl } from "@/lib/app";
 import {
   getRelatedIndustries,
   industryStats,
@@ -148,7 +149,7 @@ export function IndustryDetailView({ industry }: IndustryDetailViewProps) {
                 · 7 dias grátis · sem fidelidade
               </p>
               <div className="flex flex-wrap gap-3">
-                <Link href="https://app.purplestock.com.br/">
+                <Link href={getAppSignupUrl()}>
                   <Button size="sm" className="ps-btn-primary">
                     <Zap className="mr-2 h-4 w-4" />
                     Teste grátis
@@ -443,7 +444,7 @@ export function IndustryDetailView({ industry }: IndustryDetailViewProps) {
           </p>
 
           <div className="mt-8 flex flex-col justify-center gap-4 sm:flex-row">
-            <Link href="https://app.purplestock.com.br/">
+            <Link href={getAppSignupUrl()}>
               <Button
                 size="lg"
                 className="ps-btn-primary px-8 py-4 text-lg shadow-[0_8px_28px_rgba(139,92,246,0.4)]"

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -6,6 +6,7 @@ import { useLanguage } from "@/contexts/LanguageContext";
 import { translations } from "@/utils/translations";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
+import { getAppLoginUrl } from "@/lib/app";
 import { trackSeoCtaClick } from "@/lib/analytics";
 
 const PRIMARY_FEATURE_LINKS = [
@@ -376,7 +377,7 @@ export function Navbar() {
           <div className="w-px h-3 bg-white/20 mx-1" />
 
           <Link
-            href="https://app.purplestock.com.br/"
+            href={getAppLoginUrl()}
             className="flex items-center gap-1 px-2 py-0.5 hover:bg-white/10 rounded-[3px] transition-colors"
             onClick={() =>
               trackSeoCtaClick({

--- a/components/pre-footer-cta.tsx
+++ b/components/pre-footer-cta.tsx
@@ -13,6 +13,7 @@ import Image from "next/image";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { getAppSignupUrl } from "@/lib/app";
 
 export function PreFooterCTA() {
   const { language } = useLanguage();
@@ -114,7 +115,7 @@ export function PreFooterCTA() {
 
           <div className="mb-14">
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="transform rounded-xl bg-gradient-to-r from-purple-600 to-purple-700 px-10 py-6 text-xl font-semibold text-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:from-purple-700 hover:to-purple-800 hover:shadow-xl"
@@ -125,7 +126,7 @@ export function PreFooterCTA() {
                 </Button>
               </Link>
 
-              <Link href="https://app.purplestock.com.br/">
+              <Link href={getAppSignupUrl()}>
                 <Button
                   size="lg"
                   className="rounded-xl border-2 border-purple-600 bg-white px-10 py-6 text-xl font-semibold text-purple-700 transition-all duration-300 hover:bg-purple-50"

--- a/components/rotating-questions-and-cta.tsx
+++ b/components/rotating-questions-and-cta.tsx
@@ -6,6 +6,7 @@ import { translations } from "@/utils/translations";
 import { ArrowRight, CheckCircle, Star, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { getAppSignupUrl } from "@/lib/app";
 
 const ROTATING_QUESTIONS = {
   pt: [
@@ -173,7 +174,7 @@ export function RotatingQuestionsAndCTA() {
           {/* CTA Buttons */}
           <div className="flex flex-col sm:flex-row gap-6 justify-center items-center">
             {/* <Link href="/coming-soon"> */}
-            <Link href="https://app.purplestock.com.br/">
+            <Link href={getAppSignupUrl()}>
               <Button
                 size="lg"
                 className="bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 text-white px-10 py-6 text-xl font-semibold shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-1 rounded-xl"
@@ -189,7 +190,7 @@ export function RotatingQuestionsAndCTA() {
             </Link>
 
             {/* <Link href="/coming-soon"> */}
-            <Link href="https://app.purplestock.com.br/">
+            <Link href={getAppSignupUrl()}>
               <Button
                 size="lg"
                 className="bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white px-10 py-6 text-xl font-semibold shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-1 rounded-xl"

--- a/lib/app.ts
+++ b/lib/app.ts
@@ -1,0 +1,48 @@
+const DEFAULT_APP_URL = "https://app.gestaobem.com";
+
+function normalizeUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function getPublicUrl(value: string | undefined, fallback: string): string {
+  if (!value) return fallback;
+
+  try {
+    return normalizeUrl(new URL(value).toString());
+  } catch {
+    return fallback;
+  }
+}
+
+export function getAppUrl(): string {
+  return getPublicUrl(process.env.NEXT_PUBLIC_APP_URL, DEFAULT_APP_URL);
+}
+
+export function getAppLoginUrl(): string {
+  return `${getAppUrl()}/login`;
+}
+
+export function getAppSignupUrl(): string {
+  return `${getAppUrl()}/sign_up`;
+}
+
+export function buildAppUrl(
+  path: "login" | "sign_up" = "sign_up",
+  searchParams?: Record<string, string>
+): string {
+  const basePath = path === "login" ? getAppLoginUrl() : getAppSignupUrl();
+
+  if (!searchParams || Object.keys(searchParams).length === 0) {
+    return basePath;
+  }
+
+  try {
+    const url = new URL(basePath);
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, value);
+    }
+    return url.toString();
+  } catch {
+    return basePath;
+  }
+}

--- a/tests/app-urls.test.ts
+++ b/tests/app-urls.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildAppUrl,
+  getAppLoginUrl,
+  getAppSignupUrl,
+  getAppUrl,
+} from "../lib/app";
+
+const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+test.after(() => {
+  if (originalAppUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  } else {
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+  }
+});
+
+test("getAppUrl uses default gestaobem URL", () => {
+  delete process.env.NEXT_PUBLIC_APP_URL;
+  assert.equal(getAppUrl(), "https://app.gestaobem.com");
+});
+
+test("getAppUrl reads NEXT_PUBLIC_APP_URL", () => {
+  process.env.NEXT_PUBLIC_APP_URL = "https://custom.example.com/";
+  assert.equal(getAppUrl(), "https://custom.example.com");
+});
+
+test("getAppLoginUrl and getAppSignupUrl append routes", () => {
+  delete process.env.NEXT_PUBLIC_APP_URL;
+  assert.equal(getAppLoginUrl(), "https://app.gestaobem.com/login");
+  assert.equal(getAppSignupUrl(), "https://app.gestaobem.com/sign_up");
+});
+
+test("buildAppUrl supports signup query params", () => {
+  delete process.env.NEXT_PUBLIC_APP_URL;
+  assert.equal(
+    buildAppUrl("sign_up", {
+      utm_source: "site",
+      utm_medium: "organic",
+      utm_campaign: "controle_almoxarifado",
+    }),
+    "https://app.gestaobem.com/sign_up?utm_source=site&utm_medium=organic&utm_campaign=controle_almoxarifado"
+  );
+});

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -1,3 +1,4 @@
+import { getAppSignupUrl } from "@/lib/app";
 import { buildWhatsAppUrl } from "@/lib/contact";
 
 export const translations = {
@@ -763,7 +764,7 @@ export const translations = {
           description: "Para começar",
           features: ["Até 10 itens", "Análises básicas", "Suporte por email"],
           buttonText: "Começar Agora",
-          buttonLink: "https://app.purplestock.com.br/",
+          buttonLink: getAppSignupUrl(),
         },
         {
           name: "Pro",
@@ -777,7 +778,7 @@ export const translations = {
             "Suporte por email",
           ],
           buttonText: "Atualizar Agora",
-          buttonLink: "https://app.purplestock.com.br/",
+          buttonLink: getAppSignupUrl(),
         },
         {
           name: "Empresarial",
@@ -1633,7 +1634,7 @@ export const translations = {
           description: "To get started",
           features: ["Up to 10 items", "Basic analytics", "Email support"],
           buttonText: "Get Started",
-          buttonLink: "https://app.purplestock.com.br/",
+          buttonLink: getAppSignupUrl(),
         },
         {
           name: "Pro",
@@ -1647,7 +1648,7 @@ export const translations = {
             "Email support",
           ],
           buttonText: "Upgrade Now",
-          buttonLink: "https://app.purplestock.com.br/",
+          buttonLink: getAppSignupUrl(),
         },
         {
           name: "Enterprise",
@@ -2524,7 +2525,7 @@ export const translations = {
             "Support par email",
           ],
           buttonText: "Commencer",
-          buttonLink: "https://app.purplestock.com.br/",
+          buttonLink: getAppSignupUrl(),
         },
         {
           name: "Pro",
@@ -2538,7 +2539,7 @@ export const translations = {
             "Support par email",
           ],
           buttonText: "Mettre à Niveau",
-          buttonLink: "https://app.purplestock.com.br/",
+          buttonLink: getAppSignupUrl(),
         },
         {
           name: "Entreprise",


### PR DESCRIPTION
## Summary

Substitui URLs hardcoded de `app.purplestock.com.br` por helpers centralizados em `lib/app.ts`, configuráveis via `NEXT_PUBLIC_APP_URL`.

- **Entrar** → `{APP_URL}/login`
- **Começar grátis / CTAs de cadastro** → `{APP_URL}/sign_up`
- **Padrão:** `https://app.gestaobem.com`

## Mudanças

- Novo `lib/app.ts` com `getAppUrl()`, `getAppLoginUrl()`, `getAppSignupUrl()` e `buildAppUrl()`
- Atualização de todos os links do site (navbar, hero, landing, blog, preços, indústrias, features, etc.)
- `NEXT_PUBLIC_APP_URL` adicionada ao `.env.example`
- Testes unitários em `tests/app-urls.test.ts`

## Configuração

```env
NEXT_PUBLIC_APP_URL=https://app.gestaobem.com
```

## Test plan

- [x] `npm test` — 30 testes passando
- [x] `npm run format:check`
- [x] `npm run lint`
- [ ] Validar navbar "Entrar" → `/login`
- [ ] Validar CTAs "Começar grátis" → `/sign_up`